### PR TITLE
ACC-2018: Allow primary key to be found with Entity#getAttributeByName()

### DIFF
--- a/contentgrid-appserver-application-model/src/main/java/com/contentgrid/appserver/application/model/Entity.java
+++ b/contentgrid-appserver-application-model/src/main/java/com/contentgrid/appserver/application/model/Entity.java
@@ -163,6 +163,9 @@ public class Entity {
      * @return an Optional containing the Attribute if found, or empty if not found
      */
     public Optional<Attribute> getAttributeByName(AttributeName attributeName) {
+        if (this.primaryKey.getName().equals(attributeName)) {
+            return Optional.of(this.primaryKey);
+        }
         return Optional.ofNullable(attributes.get(attributeName));
     }
 


### PR DESCRIPTION
primary key is no longer present in `Entity.attributes`. This PR makes it possible to look it up again with `Entity#getAttributeByName()`