### PR TITLE
ACC-2052 rename CompositeAttribute to CompositAttributeImpl + add CompositeAttribute interface

### DIFF
--- a/contentgrid-appserver-application-model/src/main/java/com/contentgrid/appserver/application/model/attributes/Attribute.java
+++ b/contentgrid-appserver-application-model/src/main/java/com/contentgrid/appserver/application/model/attributes/Attribute.java
@@ -6,7 +6,7 @@ import com.contentgrid.appserver.application.model.values.ColumnName;
 import java.util.List;
 import java.util.Set;
 
-public sealed interface Attribute permits CompositeAttribute, ContentAttribute, SimpleAttribute, UserAttribute {
+public sealed interface Attribute permits CompositeAttribute, SimpleAttribute {
 
     AttributeName getName();
 

--- a/contentgrid-appserver-application-model/src/main/java/com/contentgrid/appserver/application/model/attributes/CompositeAttribute.java
+++ b/contentgrid-appserver-application-model/src/main/java/com/contentgrid/appserver/application/model/attributes/CompositeAttribute.java
@@ -1,65 +1,18 @@
 package com.contentgrid.appserver.application.model.attributes;
 
-import com.contentgrid.appserver.application.model.attributes.flags.AttributeFlag;
-import com.contentgrid.appserver.application.model.exceptions.DuplicateElementException;
 import com.contentgrid.appserver.application.model.values.AttributeName;
 import com.contentgrid.appserver.application.model.values.ColumnName;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NonNull;
-import lombok.Singular;
-import lombok.Value;
 
-@Value
-public class CompositeAttribute implements Attribute {
-
-    @NonNull
-    AttributeName name;
-
-    String description;
-
-    Set<AttributeFlag> flags;
-
-    @Getter(AccessLevel.NONE)
-    Map<AttributeName, Attribute> attributes = new HashMap<>();
-
-    @Builder
-    CompositeAttribute(@NonNull AttributeName name, String description, @Singular Set<Attribute> attributes, @Singular Set<AttributeFlag> flags) {
-        this.name = name;
-        this.description = description;
-        this.flags = flags;
-        for (var attribute : attributes) {
-            if (this.attributes.put(attribute.getName(), attribute) != null) {
-                throw new DuplicateElementException("Duplicate attribute named %s".formatted(attribute.getName()));
-            }
-        }
-        for (var flag : this.flags) {
-            flag.checkSupported(this);
-        }
-    }
+public sealed interface CompositeAttribute extends Attribute permits CompositeAttributeImpl, ContentAttribute, UserAttribute {
 
     /**
      * Returns an unmodifiable list of attributes.
      *
      * @return an unmodifiable list of attributes
      */
-    public List<Attribute> getAttributes() {
-        return List.copyOf(attributes.values());
-    }
-
-    @Override
-    public List<ColumnName> getColumns() {
-        return attributes.values().stream()
-                .map(Attribute::getColumns)
-                .flatMap(List::stream)
-                .toList();
-    }
+    List<Attribute> getAttributes();
 
     /**
      * Finds an Attribute by its name.
@@ -67,7 +20,16 @@ public class CompositeAttribute implements Attribute {
      * @param attributeName the name of the attribute to find
      * @return an Optional containing the Attribute if found, or empty if not found
      */
-    public Optional<Attribute> getAttributeByName(AttributeName attributeName) {
-        return Optional.ofNullable(attributes.get(attributeName));
+    default Optional<Attribute> getAttributeByName(AttributeName attributeName) {
+        return getAttributes().stream()
+                .filter(attribute -> attribute.getName().equals(attributeName))
+                .findAny();
+    }
+
+    @Override
+    default List<ColumnName> getColumns() {
+        return getAttributes().stream()
+                .flatMap(attribute -> attribute.getColumns().stream())
+                .toList();
     }
 }

--- a/contentgrid-appserver-application-model/src/main/java/com/contentgrid/appserver/application/model/attributes/CompositeAttributeImpl.java
+++ b/contentgrid-appserver-application-model/src/main/java/com/contentgrid/appserver/application/model/attributes/CompositeAttributeImpl.java
@@ -1,0 +1,66 @@
+package com.contentgrid.appserver.application.model.attributes;
+
+import com.contentgrid.appserver.application.model.attributes.flags.AttributeFlag;
+import com.contentgrid.appserver.application.model.exceptions.DuplicateElementException;
+import com.contentgrid.appserver.application.model.values.AttributeName;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.Singular;
+import lombok.Value;
+
+@Value
+public class CompositeAttributeImpl implements CompositeAttribute {
+
+    @NonNull
+    AttributeName name;
+
+    String description;
+
+    Set<AttributeFlag> flags;
+
+    @Getter(AccessLevel.NONE)
+    Map<AttributeName, Attribute> attributes = new HashMap<>();
+
+    @Builder
+    CompositeAttributeImpl(@NonNull AttributeName name, String description, @Singular Set<Attribute> attributes, @Singular Set<AttributeFlag> flags) {
+        this.name = name;
+        this.description = description;
+        this.flags = flags;
+        for (var attribute : attributes) {
+            if (this.attributes.put(attribute.getName(), attribute) != null) {
+                throw new DuplicateElementException("Duplicate attribute named %s".formatted(attribute.getName()));
+            }
+        }
+        for (var flag : this.flags) {
+            flag.checkSupported(this);
+        }
+    }
+
+    /**
+     * Returns an unmodifiable list of attributes.
+     *
+     * @return an unmodifiable list of attributes
+     */
+    @Override
+    public List<Attribute> getAttributes() {
+        return List.copyOf(attributes.values());
+    }
+
+    /**
+     * Finds an Attribute by its name.
+     *
+     * @param attributeName the name of the attribute to find
+     * @return an Optional containing the Attribute if found, or empty if not found
+     */
+    @Override
+    public Optional<Attribute> getAttributeByName(AttributeName attributeName) {
+        return Optional.ofNullable(attributes.get(attributeName));
+    }
+}

--- a/contentgrid-appserver-application-model/src/main/java/com/contentgrid/appserver/application/model/attributes/ContentAttribute.java
+++ b/contentgrid-appserver-application-model/src/main/java/com/contentgrid/appserver/application/model/attributes/ContentAttribute.java
@@ -14,7 +14,7 @@ import lombok.Singular;
 import lombok.Value;
 
 @Value
-public class ContentAttribute implements Attribute {
+public class ContentAttribute implements CompositeAttribute {
 
     @NonNull
     AttributeName name;
@@ -50,9 +50,9 @@ public class ContentAttribute implements Attribute {
                 .type(Type.TEXT).build();
         this.filename = SimpleAttribute.builder().name(AttributeName.of("filename")).column(filenameColumn)
                 .type(Type.TEXT).build();
-        this.mimetype  = SimpleAttribute.builder().name(AttributeName.of("mimetype")).column(mimetypeColumn)
+        this.mimetype = SimpleAttribute.builder().name(AttributeName.of("mimetype")).column(mimetypeColumn)
                 .type(Type.TEXT).build();
-        this.length  = SimpleAttribute.builder().name(AttributeName.of("length")).column(lengthColumn)
+        this.length = SimpleAttribute.builder().name(AttributeName.of("length")).column(lengthColumn)
                 .type(Type.LONG).build();
 
         for (var flag : this.flags) {
@@ -61,9 +61,7 @@ public class ContentAttribute implements Attribute {
     }
 
     @Override
-    public List<ColumnName> getColumns() {
-        return Stream.of(id.getColumns(), filename.getColumns(), mimetype.getColumns(), length.getColumns())
-                .flatMap(List::stream)
-                .toList();
+    public List<Attribute> getAttributes() {
+        return Stream.of(id, filename, mimetype, length).toList();
     }
 }

--- a/contentgrid-appserver-application-model/src/main/java/com/contentgrid/appserver/application/model/attributes/SimpleAttribute.java
+++ b/contentgrid-appserver-application-model/src/main/java/com/contentgrid/appserver/application/model/attributes/SimpleAttribute.java
@@ -58,8 +58,6 @@ public class SimpleAttribute implements Attribute {
         TEXT,
         DATETIME,
         UUID;
-
-        public static final Set<Type> NATIVE_TYPES = Set.of(TEXT, UUID, LONG, DOUBLE, BOOLEAN, DATETIME);
     }
 
     @Builder

--- a/contentgrid-appserver-application-model/src/main/java/com/contentgrid/appserver/application/model/attributes/UserAttribute.java
+++ b/contentgrid-appserver-application-model/src/main/java/com/contentgrid/appserver/application/model/attributes/UserAttribute.java
@@ -13,7 +13,7 @@ import lombok.Singular;
 import lombok.Value;
 
 @Value
-public class UserAttribute implements Attribute {
+public class UserAttribute implements CompositeAttribute {
 
     @NonNull
     AttributeName name;
@@ -50,9 +50,7 @@ public class UserAttribute implements Attribute {
     }
 
     @Override
-    public List<ColumnName> getColumns() {
-        return Stream.of(id.getColumns(), namespace.getColumns(), username.getColumns())
-                .flatMap(List::stream)
-                .toList();
+    public List<Attribute> getAttributes() {
+        return Stream.of(id, namespace, username).toList();
     }
 }

--- a/contentgrid-appserver-application-model/src/main/java/com/contentgrid/appserver/application/model/searchfilters/ExactSearchFilter.java
+++ b/contentgrid-appserver-application-model/src/main/java/com/contentgrid/appserver/application/model/searchfilters/ExactSearchFilter.java
@@ -4,6 +4,7 @@ import com.contentgrid.appserver.application.model.attributes.SimpleAttribute;
 import com.contentgrid.appserver.application.model.attributes.SimpleAttribute.Type;
 import com.contentgrid.appserver.application.model.exceptions.InvalidSearchFilterException;
 import com.contentgrid.appserver.application.model.values.FilterName;
+import java.util.Set;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.NonNull;
@@ -33,6 +34,6 @@ public class ExactSearchFilter extends AttributeSearchFilter {
 
     @Override
     protected boolean supports(Type type) {
-        return Type.NATIVE_TYPES.contains(type);
+        return Set.of(Type.values()).contains(type);
     }
 }

--- a/contentgrid-appserver-application-model/src/test/java/com/contentgrid/appserver/application/model/ApplicationTest.java
+++ b/contentgrid-appserver-application-model/src/test/java/com/contentgrid/appserver/application/model/ApplicationTest.java
@@ -3,7 +3,7 @@ package com.contentgrid.appserver.application.model;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import com.contentgrid.appserver.application.model.attributes.CompositeAttribute;
+import com.contentgrid.appserver.application.model.attributes.CompositeAttributeImpl;
 import com.contentgrid.appserver.application.model.attributes.ContentAttribute;
 import com.contentgrid.appserver.application.model.attributes.SimpleAttribute;
 import com.contentgrid.appserver.application.model.attributes.SimpleAttribute.Type;
@@ -310,7 +310,7 @@ class ApplicationTest {
                 .lengthColumn(ColumnName.of("document__length"))
                 .build();
 
-        var orderAudit = CompositeAttribute.builder()
+        var orderAudit = CompositeAttributeImpl.builder()
                 .name(AttributeName.of("auditing"))
                 .attribute(UserAttribute.builder()
                         .name(AttributeName.of("created_by"))

--- a/contentgrid-appserver-application-model/src/test/java/com/contentgrid/appserver/application/model/AttributeTest.java
+++ b/contentgrid-appserver-application-model/src/test/java/com/contentgrid/appserver/application/model/AttributeTest.java
@@ -6,7 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.contentgrid.appserver.application.model.attributes.Attribute;
-import com.contentgrid.appserver.application.model.attributes.CompositeAttribute;
+import com.contentgrid.appserver.application.model.attributes.CompositeAttributeImpl;
 import com.contentgrid.appserver.application.model.attributes.ContentAttribute;
 import com.contentgrid.appserver.application.model.attributes.SimpleAttribute;
 import com.contentgrid.appserver.application.model.attributes.SimpleAttribute.Type;
@@ -119,7 +119,7 @@ class AttributeTest {
 
     @Test
     void compositeAttribute_auditMetadata() {
-        var attribute = CompositeAttribute.builder()
+        var attribute = CompositeAttributeImpl.builder()
                 .name(AttributeName.of("auditing"))
                 .attribute(UserAttribute.builder()
                         .name(AttributeName.of("created_by"))

--- a/contentgrid-appserver-query-engine/src/main/java/com/contentgrid/appserver/query/engine/JOOQTableCreator.java
+++ b/contentgrid-appserver-query-engine/src/main/java/com/contentgrid/appserver/query/engine/JOOQTableCreator.java
@@ -6,9 +6,7 @@ import com.contentgrid.appserver.application.model.Constraint.UniqueConstraint;
 import com.contentgrid.appserver.application.model.Entity;
 import com.contentgrid.appserver.application.model.attributes.Attribute;
 import com.contentgrid.appserver.application.model.attributes.CompositeAttribute;
-import com.contentgrid.appserver.application.model.attributes.ContentAttribute;
 import com.contentgrid.appserver.application.model.attributes.SimpleAttribute;
-import com.contentgrid.appserver.application.model.attributes.UserAttribute;
 import com.contentgrid.appserver.application.model.relations.ManyToManyRelation;
 import com.contentgrid.appserver.application.model.relations.ManyToOneRelation;
 import com.contentgrid.appserver.application.model.relations.OneToManyRelation;
@@ -102,17 +100,6 @@ public class JOOQTableCreator {
                     step = createColumnsForAttribute(step, nestedAttribute);
                 }
                 return step;
-            }
-            case ContentAttribute contentAttribute -> {
-                step = createColumnsForAttribute(step, contentAttribute.getId());
-                step = createColumnsForAttribute(step, contentAttribute.getFilename());
-                step = createColumnsForAttribute(step, contentAttribute.getMimetype());
-                return createColumnsForAttribute(step, contentAttribute.getLength());
-            }
-            case UserAttribute userAttribute -> {
-                step = createColumnsForAttribute(step, userAttribute.getId());
-                step = createColumnsForAttribute(step, userAttribute.getNamespace());
-                return createColumnsForAttribute(step, userAttribute.getUsername());
             }
         }
     }

--- a/contentgrid-appserver-query-engine/src/test/java/com/contentgrid/appserver/query/engine/JOOQTableCreatorTest.java
+++ b/contentgrid-appserver-query-engine/src/test/java/com/contentgrid/appserver/query/engine/JOOQTableCreatorTest.java
@@ -8,6 +8,7 @@ import com.contentgrid.appserver.application.model.Application;
 import com.contentgrid.appserver.application.model.Constraint;
 import com.contentgrid.appserver.application.model.Entity;
 import com.contentgrid.appserver.application.model.attributes.CompositeAttribute;
+import com.contentgrid.appserver.application.model.attributes.CompositeAttributeImpl;
 import com.contentgrid.appserver.application.model.attributes.ContentAttribute;
 import com.contentgrid.appserver.application.model.attributes.SimpleAttribute;
 import com.contentgrid.appserver.application.model.attributes.SimpleAttribute.Type;
@@ -135,7 +136,7 @@ class JOOQTableCreatorTest {
             .lengthColumn(ColumnName.of("content__length"))
             .build();
 
-    private static final CompositeAttribute INVOICE_AUDIT_METADATA = CompositeAttribute.builder()
+    private static final CompositeAttribute INVOICE_AUDIT_METADATA = CompositeAttributeImpl.builder()
             .name(AttributeName.of("audit_metadata"))
             .attribute(SimpleAttribute.builder()
                     .name(AttributeName.of("created_date"))


### PR DESCRIPTION
CompositeAttribute contains getAttributeByName() and getAttributes() methods. Its implementations are CompositeAttributeImpl, ContentAttribute and UserAttribute.