### PR TITLE
[ACC-2269] Handle transactions for QueryEngine manually

### DIFF
--- a/contentgrid-appserver-app/src/main/java/com/contentgrid/appserver/ContentgridAppConfiguration.java
+++ b/contentgrid-appserver-app/src/main/java/com/contentgrid/appserver/ContentgridAppConfiguration.java
@@ -39,6 +39,7 @@ import com.contentgrid.appserver.query.engine.api.QueryEngine;
 import com.contentgrid.appserver.query.engine.api.TableCreator;
 import com.contentgrid.appserver.query.engine.jooq.JOOQQueryEngine;
 import com.contentgrid.appserver.query.engine.jooq.JOOQTableCreator;
+import com.contentgrid.appserver.query.engine.jooq.TransactionalQueryEngine;
 import com.contentgrid.appserver.query.engine.jooq.count.JOOQCountStrategy;
 import com.contentgrid.appserver.query.engine.jooq.count.JOOQTimedCountStrategy;
 import com.contentgrid.appserver.query.engine.jooq.resolver.AutowiredDSLContextResolver;
@@ -64,6 +65,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.type.AnnotatedTypeMetadata;
+import org.springframework.transaction.PlatformTransactionManager;
 
 @Slf4j
 @Configuration(proxyBeanMethods = false)
@@ -102,8 +104,11 @@ public class ContentgridAppConfiguration {
     }
 
     @Bean
-    public QueryEngine jooqQueryEngine(DSLContextResolver dslContextResolver, JOOQCountStrategy countStrategy) {
-        return new JOOQQueryEngine(dslContextResolver, countStrategy);
+    public QueryEngine jooqQueryEngine(DSLContextResolver dslContextResolver, JOOQCountStrategy countStrategy, PlatformTransactionManager transactionManager) {
+        return new TransactionalQueryEngine(
+                new JOOQQueryEngine(dslContextResolver, countStrategy),
+                transactionManager
+        ) ;
     }
 
     @Bean

--- a/contentgrid-appserver-query-engine-impl-jooq/src/main/java/com/contentgrid/appserver/query/engine/jooq/JOOQQueryEngine.java
+++ b/contentgrid-appserver-query-engine-impl-jooq/src/main/java/com/contentgrid/appserver/query/engine/jooq/JOOQQueryEngine.java
@@ -62,10 +62,8 @@ import org.jooq.exception.IntegrityConstraintViolationException;
 import org.jooq.impl.DSL;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.dao.DuplicateKeyException;
-import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
-@Transactional
 public class JOOQQueryEngine implements QueryEngine {
 
     @NonNull

--- a/contentgrid-appserver-query-engine-impl-jooq/src/main/java/com/contentgrid/appserver/query/engine/jooq/TransactionalQueryEngine.java
+++ b/contentgrid-appserver-query-engine-impl-jooq/src/main/java/com/contentgrid/appserver/query/engine/jooq/TransactionalQueryEngine.java
@@ -1,0 +1,171 @@
+package com.contentgrid.appserver.query.engine.jooq;
+
+import com.contentgrid.appserver.application.model.Application;
+import com.contentgrid.appserver.application.model.Entity;
+import com.contentgrid.appserver.application.model.relations.Relation;
+import com.contentgrid.appserver.domain.values.EntityId;
+import com.contentgrid.appserver.domain.values.EntityRequest;
+import com.contentgrid.appserver.domain.values.ItemCount;
+import com.contentgrid.appserver.query.engine.api.QueryEngine;
+import com.contentgrid.appserver.query.engine.api.UpdateResult;
+import com.contentgrid.appserver.query.engine.api.data.EntityCreateData;
+import com.contentgrid.appserver.query.engine.api.data.EntityData;
+import com.contentgrid.appserver.query.engine.api.data.QueryPageData;
+import com.contentgrid.appserver.query.engine.api.data.SliceData;
+import com.contentgrid.appserver.query.engine.api.data.SortData;
+import com.contentgrid.appserver.query.engine.api.exception.QueryEngineException;
+import com.contentgrid.thunx.predicates.model.ThunkExpression;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Supplier;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@RequiredArgsConstructor
+public class TransactionalQueryEngine implements QueryEngine {
+    @NonNull
+    private final QueryEngine delegate;
+
+    @NonNull
+    private final PlatformTransactionManager transactionManager;
+
+    private <T> T runInReadOnlyTransaction(Supplier<T> callable) {
+        var tpl = new TransactionTemplate(transactionManager);
+        tpl.setReadOnly(true);
+
+        return tpl.execute(tx -> callable.get());
+    }
+
+    private <T> T runInWriteTransaction(Supplier<T> callable) {
+        var tpl = new TransactionTemplate(transactionManager);
+
+        return tpl.execute(tx -> {
+            var savepoint = tx.createSavepoint();
+            var hasThrown = true;
+            try {
+                var ret = callable.get();
+                hasThrown = false;
+                return ret;
+            } finally {
+                if(hasThrown) {
+                    tx.rollbackToSavepoint(savepoint);
+                }
+            }
+        });
+    }
+
+    @Override
+    public SliceData findAll(@NonNull Application application, @NonNull Entity entity,
+            @NonNull ThunkExpression<Boolean> expression, SortData sortData, @NonNull QueryPageData page)
+            throws QueryEngineException {
+        return runInReadOnlyTransaction(() ->
+                delegate.findAll(application, entity, expression, sortData, page)
+        );
+    }
+
+    @Override
+    public Optional<EntityData> findById(@NonNull Application application, @NonNull EntityRequest entityRequest,
+            @NonNull ThunkExpression<Boolean> permitReadPredicate) throws QueryEngineException {
+        return runInReadOnlyTransaction(() ->
+                delegate.findById(application, entityRequest, permitReadPredicate)
+        );
+    }
+
+    @Override
+    public EntityData create(@NonNull Application application, @NonNull EntityCreateData data,
+            @NonNull ThunkExpression<Boolean> permitCreatePredicate) throws QueryEngineException {
+        return runInWriteTransaction(() ->
+                delegate.create(application, data, permitCreatePredicate)
+        );
+    }
+
+    @Override
+    public UpdateResult update(@NonNull Application application, @NonNull EntityData data,
+            @NonNull ThunkExpression<Boolean> permitUpdatePredicate) throws QueryEngineException {
+        return runInWriteTransaction(() ->
+                delegate.update(application, data, permitUpdatePredicate)
+        );
+    }
+
+    @Override
+    public Optional<EntityData> delete(@NonNull Application application, @NonNull EntityRequest entityRequest,
+            @NonNull ThunkExpression<Boolean> permitDeletePredicate) throws QueryEngineException {
+        return runInWriteTransaction(() ->
+                delegate.delete(application, entityRequest, permitDeletePredicate)
+        );
+    }
+
+    @Override
+    public void deleteAll(@NonNull Application application, @NonNull Entity entity) throws QueryEngineException {
+        runInWriteTransaction(() -> {
+            delegate.deleteAll(application, entity);
+            return null;
+        });
+    }
+
+    @Override
+    public boolean isLinked(@NonNull Application application, @NonNull Relation relation, @NonNull EntityId sourceId,
+            @NonNull EntityId targetId, @NonNull ThunkExpression<Boolean> permitReadPredicate)
+            throws QueryEngineException {
+        return runInReadOnlyTransaction(() ->
+                delegate.isLinked(application, relation, sourceId, targetId, permitReadPredicate)
+        );
+    }
+
+    @Override
+    public Optional<EntityId> findTarget(@NonNull Application application, @NonNull Relation relation,
+            @NonNull EntityId id, @NonNull ThunkExpression<Boolean> permitReadPredicate) throws QueryEngineException {
+        return runInReadOnlyTransaction(() ->
+                delegate.findTarget(application, relation, id, permitReadPredicate)
+        );
+    }
+
+    @Override
+    public void setLink(@NonNull Application application, @NonNull Relation relation, @NonNull EntityId id,
+            @NonNull EntityId targetId, @NonNull ThunkExpression<Boolean> permitUpdatePredicate)
+            throws QueryEngineException {
+        runInWriteTransaction(() -> {
+            delegate.setLink(application, relation, id, targetId, permitUpdatePredicate);
+            return null;
+        });
+    }
+
+    @Override
+    public void unsetLink(@NonNull Application application, @NonNull Relation relation, @NonNull EntityId id,
+            @NonNull ThunkExpression<Boolean> permitUpdatePredicate) throws QueryEngineException {
+        runInWriteTransaction(() -> {
+            delegate.unsetLink(application, relation, id, permitUpdatePredicate);
+            return null;
+        });
+    }
+
+    @Override
+    public void addLinks(@NonNull Application application, @NonNull Relation relation, @NonNull EntityId id,
+            @NonNull Set<EntityId> targetIds, @NonNull ThunkExpression<Boolean> permitUpdatePredicate)
+            throws QueryEngineException {
+        runInWriteTransaction(() -> {
+            delegate.addLinks(application, relation, id, targetIds, permitUpdatePredicate);
+            return null;
+        });
+    }
+
+    @Override
+    public void removeLinks(@NonNull Application application, @NonNull Relation relation, @NonNull EntityId id,
+            @NonNull Set<EntityId> targetIds, @NonNull ThunkExpression<Boolean> permitUpdatePredicate)
+            throws QueryEngineException {
+        runInWriteTransaction(() -> {
+            delegate.removeLinks(application, relation, id, targetIds, permitUpdatePredicate);
+            return null;
+        });
+    }
+
+    @Override
+    public ItemCount count(@NonNull Application application, @NonNull Entity entity,
+            @NonNull ThunkExpression<Boolean> expression) throws QueryEngineException {
+        return runInReadOnlyTransaction(() ->
+                delegate.count(application, entity, expression)
+        );
+    }
+}

--- a/contentgrid-appserver-query-engine-impl-jooq/src/test/java/com/contentgrid/appserver/query/engine/jooq/JOOQQueryEngineTest.java
+++ b/contentgrid-appserver-query-engine-impl-jooq/src/test/java/com/contentgrid/appserver/query/engine/jooq/JOOQQueryEngineTest.java
@@ -105,6 +105,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.transaction.PlatformTransactionManager;
 
 @SpringBootTest(properties = {
         "spring.datasource.url=jdbc:tc:postgresql:15:///",
@@ -2363,8 +2364,11 @@ class JOOQQueryEngineTest {
         }
 
         @Bean
-        public QueryEngine jooqQueryEngine(DSLContextResolver dslContextResolver) {
-            return new JOOQQueryEngine(dslContextResolver, new JOOQTimedCountStrategy(Duration.ofMillis(500)));
+        public QueryEngine jooqQueryEngine(DSLContextResolver dslContextResolver, PlatformTransactionManager transactionManager) {
+            return new TransactionalQueryEngine(
+                    new JOOQQueryEngine(dslContextResolver, new JOOQTimedCountStrategy(Duration.ofMillis(500))),
+                    transactionManager
+            );
         }
     }
 }


### PR DESCRIPTION
There are dangerous gotchas by using the `@Transactional` annotation on
the implementation class only.

Default methods on the `QueryEngine` interface will not run inside a
transaction at all.
This happens because:
1. the interceptor does not intercept those methods directly (as they
   are not annotated)
2. calls to `this` are never intercepted by interceptors (because they
   are dispatched internally, and don't pass the proxy object that
intercepts methods)

The result is that adding default methods to `QueryEngine` is dangerous,
because it bypasses transaction management.
We explicitly rely on rolling back transactions for permission
management. Being non-transactional would mean that changes will go
through, even though a permission exception is thrown to revert the
change.
