### PR TITLE
ACC-2304: always render properties in HalFormsTemplate as list

### DIFF
--- a/contentgrid-appserver-rest/src/main/java/com/contentgrid/appserver/rest/hal/forms/HalFormsTemplate.java
+++ b/contentgrid-appserver-rest/src/main/java/com/contentgrid/appserver/rest/hal/forms/HalFormsTemplate.java
@@ -37,7 +37,6 @@ public class HalFormsTemplate {
     String target;
 
     @Singular
-    @JsonInclude(Include.NON_EMPTY)
     List<HalFormsProperty> properties;
 
     @JsonProperty


### PR DESCRIPTION
contentgrid-ts fails to parse it when properties is not present. Spring-hateoas also doesn't have the `@JsonInclude(Include.NON_EMPTY)` for properties.