### PR TITLE
Register all HandlerMethodArgumentResolver as beans, and pull in all those beans in customization

### DIFF
--- a/contentgrid-appserver-rest/src/main/java/com/contentgrid/appserver/rest/ApplicationArgumentResolver.java
+++ b/contentgrid-appserver-rest/src/main/java/com/contentgrid/appserver/rest/ApplicationArgumentResolver.java
@@ -6,12 +6,14 @@ import com.contentgrid.appserver.registry.ApplicationResolver;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
 import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
 @RequiredArgsConstructor
+@Component
 public class ApplicationArgumentResolver implements HandlerMethodArgumentResolver {
 
     private final ApplicationResolver resolver;

--- a/contentgrid-appserver-rest/src/main/java/com/contentgrid/appserver/rest/AuthorizationContextArgumentResolver.java
+++ b/contentgrid-appserver-rest/src/main/java/com/contentgrid/appserver/rest/AuthorizationContextArgumentResolver.java
@@ -10,12 +10,14 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.stereotype.Component;
 import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
 @RequiredArgsConstructor
+@Component
 public class AuthorizationContextArgumentResolver implements HandlerMethodArgumentResolver {
     private final AbacContextSupplier abacContextSupplier;
 

--- a/contentgrid-appserver-rest/src/main/java/com/contentgrid/appserver/rest/ContentGridRestConfiguration.java
+++ b/contentgrid-appserver-rest/src/main/java/com/contentgrid/appserver/rest/ContentGridRestConfiguration.java
@@ -2,8 +2,6 @@ package com.contentgrid.appserver.rest;
 
 import com.contentgrid.appserver.domain.data.EntityInstance;
 import com.contentgrid.appserver.domain.values.EntityId;
-import com.contentgrid.appserver.registry.ApplicationNameExtractor;
-import com.contentgrid.appserver.registry.ApplicationResolver;
 import com.contentgrid.appserver.registry.DefaultApplicationNameExtractor;
 import com.contentgrid.appserver.rest.assembler.EntityDataRepresentationModelAssembler;
 import com.contentgrid.appserver.rest.assembler.profile.BlueprintLinkRelationsConfiguration;
@@ -24,7 +22,6 @@ import com.contentgrid.appserver.rest.property.XToManyRelationRestController;
 import com.contentgrid.appserver.rest.property.XToOneRelationRestController;
 import com.contentgrid.hateoas.spring.pagination.PaginationHandlerMethodArgumentResolver;
 import com.contentgrid.hateoas.spring.pagination.SlicedResourcesAssembler;
-import com.contentgrid.thunx.spring.data.context.AbacContextSupplier;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import java.text.ParseException;
 import java.util.List;
@@ -62,19 +59,19 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
         UriListHttpMessageConverter.class,
         XToManyRelationRestController.class,
         XToOneRelationRestController.class,
+        ApplicationArgumentResolver.class,
+        AuthorizationContextArgumentResolver.class,
+        EncodedCursorPaginationHandlerMethodArgumentResolver.class,
+        VersionConstraintArgumentResolver.class
 })
 public class ContentGridRestConfiguration {
     @Bean
-    WebMvcConfigurer contentgridRestWebmvcConfigurer(ApplicationResolver applicationResolver, ApplicationNameExtractor applicationNameExtractor,
-            AbacContextSupplier abacContextSupplier, EncodedCursorPaginationHandlerMethodArgumentResolver paginationHandlerMethodArgumentResolver) {
+    WebMvcConfigurer contentgridRestWebmvcConfigurer(List<HandlerMethodArgumentResolver> customResolvers) {
         return new WebMvcConfigurer() {
 
             @Override
             public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
-                resolvers.add(new ApplicationArgumentResolver(applicationResolver, applicationNameExtractor));
-                resolvers.add(new VersionConstraintArgumentResolver());
-                resolvers.add(new AuthorizationContextArgumentResolver(abacContextSupplier));
-                resolvers.add(paginationHandlerMethodArgumentResolver);
+                resolvers.addAll(customResolvers);
             }
 
             @Override
@@ -113,11 +110,6 @@ public class ContentGridRestConfiguration {
     @Bean
     SlicedResourcesAssembler<EntityInstance> slicedResourcesAssembler(PaginationHandlerMethodArgumentResolver resolver) {
         return new SlicedResourcesAssembler<>(resolver);
-    }
-
-    @Bean
-    EncodedCursorPaginationHandlerMethodArgumentResolver encodedCursorPaginationHandlerMethodArgumentResolver() {
-        return new EncodedCursorPaginationHandlerMethodArgumentResolver();
     }
 
 }

--- a/contentgrid-appserver-rest/src/main/java/com/contentgrid/appserver/rest/EncodedCursorPaginationHandlerMethodArgumentResolver.java
+++ b/contentgrid-appserver-rest/src/main/java/com/contentgrid/appserver/rest/EncodedCursorPaginationHandlerMethodArgumentResolver.java
@@ -18,12 +18,14 @@ import java.util.stream.Collectors;
 import org.springframework.core.MethodParameter;
 import org.springframework.hateoas.server.mvc.UriComponentsContributor;
 import org.springframework.lang.Nullable;
+import org.springframework.stereotype.Component;
 import org.springframework.util.Assert;
 import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.ModelAndViewContainer;
 import org.springframework.web.util.UriComponentsBuilder;
 
+@Component
 public class EncodedCursorPaginationHandlerMethodArgumentResolver extends PaginationHandlerMethodArgumentResolver
         implements PaginationSystem, UriComponentsContributor {
 

--- a/contentgrid-appserver-rest/src/main/java/com/contentgrid/appserver/rest/VersionConstraintArgumentResolver.java
+++ b/contentgrid-appserver-rest/src/main/java/com/contentgrid/appserver/rest/VersionConstraintArgumentResolver.java
@@ -16,6 +16,7 @@ import org.springframework.core.convert.converter.Converter;
 import org.springframework.http.ETag;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
@@ -26,6 +27,7 @@ import org.springframework.web.server.ResponseStatusException;
 /**
  * Resolves ETags from If-Match/If-None-Match headers to {@link VersionConstraint} objects
  */
+@Component
 public class VersionConstraintArgumentResolver implements HandlerMethodArgumentResolver, Converter<Version, ETag> {
 
     @Override


### PR DESCRIPTION
This reduces the manual wiring required to set up all the `HandlerMethodArgumentResolver`s by making them easily available as beans themselves.

Unfortunately, it's not possible to enable enable classpath scanning on the `ContentGridRestConfiguration`, as that also picks up test configurations in the tests, which causes a whole lot of bean definition conflicts