### PR TITLE
[ACC-2230] Add LinkProvider for a centralized place to create links

### DIFF
--- a/contentgrid-appserver-rest/src/main/java/com/contentgrid/appserver/rest/ContentGridRestConfiguration.java
+++ b/contentgrid-appserver-rest/src/main/java/com/contentgrid/appserver/rest/ContentGridRestConfiguration.java
@@ -62,7 +62,8 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
         ApplicationArgumentResolver.class,
         AuthorizationContextArgumentResolver.class,
         EncodedCursorPaginationHandlerMethodArgumentResolver.class,
-        VersionConstraintArgumentResolver.class
+        VersionConstraintArgumentResolver.class,
+        LinkProviderArgumentResolver.class,
 })
 public class ContentGridRestConfiguration {
     @Bean

--- a/contentgrid-appserver-rest/src/main/java/com/contentgrid/appserver/rest/LinkProviderArgumentResolver.java
+++ b/contentgrid-appserver-rest/src/main/java/com/contentgrid/appserver/rest/LinkProviderArgumentResolver.java
@@ -1,0 +1,32 @@
+package com.contentgrid.appserver.rest;
+
+import com.contentgrid.appserver.rest.links.factory.LinkFactoryProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.hateoas.server.MethodLinkBuilderFactory;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@RequiredArgsConstructor
+public class LinkProviderArgumentResolver implements HandlerMethodArgumentResolver {
+    private final MethodLinkBuilderFactory<?> linkBuilderFactory;
+    private final ApplicationArgumentResolver applicationArgumentResolver;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.getParameterType().isAssignableFrom(LinkFactoryProvider.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+            NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        var application = applicationArgumentResolver.resolveArgument(parameter, mavContainer, webRequest, binderFactory);
+
+        return new LinkFactoryProvider(
+                application,
+                linkBuilderFactory
+        );
+    }
+}

--- a/contentgrid-appserver-rest/src/main/java/com/contentgrid/appserver/rest/ProfileRestController.java
+++ b/contentgrid-appserver-rest/src/main/java/com/contentgrid/appserver/rest/ProfileRestController.java
@@ -8,6 +8,7 @@ import com.contentgrid.appserver.rest.assembler.profile.hal.ProfileEntityReprese
 import com.contentgrid.appserver.rest.assembler.profile.hal.ProfileEntityRepresentationModelAssembler;
 import com.contentgrid.appserver.rest.assembler.profile.json.JsonSchema;
 import com.contentgrid.appserver.rest.assembler.profile.json.JsonSchemaAssembler;
+import com.contentgrid.appserver.rest.links.factory.LinkFactoryProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.hateoas.MediaTypes;
 import org.springframework.http.HttpStatus;
@@ -27,17 +28,19 @@ public class ProfileRestController {
     private final JsonSchemaAssembler jsonSchemaAssembler = new JsonSchemaAssembler();
 
     @GetMapping
-    public EmptyRepresentationModel getProfile(Application application) {
-        return profileRootAssembler.toModel(application);
+    public EmptyRepresentationModel getProfile(Application application, LinkFactoryProvider linkFactoryProvider) {
+        return profileRootAssembler.withContext(linkFactoryProvider).toModel(application);
     }
 
     @GetMapping(value = "/{entityName}", produces = MediaTypes.HAL_FORMS_JSON_VALUE)
     public ProfileEntityRepresentationModel getHalFormsEntityProfile(
-            Application application, @PathVariable PathSegmentName entityName
+            Application application, @PathVariable PathSegmentName entityName,
+            LinkFactoryProvider linkFactoryProvider
     ) {
         var entity = application.getEntityByPathSegment(entityName)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
-        return profileEntityAssembler.withContext(application).toModel(entity);
+        return profileEntityAssembler.withContext(new ProfileEntityRepresentationModelAssembler.Context(application,
+                linkFactoryProvider)).toModel(entity);
     }
 
     @GetMapping(value = "/{entityName}", produces = "application/schema+json")

--- a/contentgrid-appserver-rest/src/main/java/com/contentgrid/appserver/rest/RootRestController.java
+++ b/contentgrid-appserver-rest/src/main/java/com/contentgrid/appserver/rest/RootRestController.java
@@ -3,6 +3,7 @@ package com.contentgrid.appserver.rest;
 import com.contentgrid.appserver.application.model.Application;
 import com.contentgrid.appserver.rest.assembler.RootRepresentationModelAssembler;
 import com.contentgrid.appserver.rest.assembler.EmptyRepresentationModel;
+import com.contentgrid.appserver.rest.links.factory.LinkFactoryProvider;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -12,8 +13,8 @@ public class RootRestController {
     private final RootRepresentationModelAssembler assembler = new RootRepresentationModelAssembler();
 
     @GetMapping("/")
-    public EmptyRepresentationModel getRoot(Application application) {
-        return assembler.toModel(application);
+    public EmptyRepresentationModel getRoot(Application application, LinkFactoryProvider linkFactoryProvider) {
+        return assembler.withContext(linkFactoryProvider).toModel(application);
     }
 
 }

--- a/contentgrid-appserver-rest/src/main/java/com/contentgrid/appserver/rest/assembler/RootRepresentationModelAssembler.java
+++ b/contentgrid-appserver-rest/src/main/java/com/contentgrid/appserver/rest/assembler/RootRepresentationModelAssembler.java
@@ -1,46 +1,35 @@
 package com.contentgrid.appserver.rest.assembler;
 
-import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
-import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
-
 import com.contentgrid.appserver.application.model.Application;
-import com.contentgrid.appserver.application.model.Entity;
-import com.contentgrid.appserver.rest.EntityRestController;
-import com.contentgrid.appserver.rest.ProfileRestController;
-import com.contentgrid.appserver.rest.RootRestController;
+import com.contentgrid.appserver.rest.assembler.RootRepresentationModelAssembler.Context;
 import com.contentgrid.appserver.rest.links.ContentGridLinkRelations;
-import java.util.Map;
+import com.contentgrid.appserver.rest.links.factory.LinkFactoryProvider;
+import com.contentgrid.appserver.rest.links.factory.LinkFactoryProvider.CollectionParameters;
+import com.contentgrid.hateoas.spring.server.RepresentationModelContextAssembler;
 import lombok.NonNull;
 import org.springframework.hateoas.IanaLinkRelations;
-import org.springframework.hateoas.Link;
 import org.springframework.hateoas.server.RepresentationModelAssembler;
-import org.springframework.util.MultiValueMap;
 
-public class RootRepresentationModelAssembler implements RepresentationModelAssembler<Application, EmptyRepresentationModel> {
+public class RootRepresentationModelAssembler implements
+        RepresentationModelContextAssembler<Application, EmptyRepresentationModel, Context> {
+
+    public RepresentationModelAssembler<Application, EmptyRepresentationModel> withContext(
+            LinkFactoryProvider linkFactoryProvider) {
+        return withContext(new Context(linkFactoryProvider));
+    }
+
+    public record Context(LinkFactoryProvider linkFactoryProvider) {
+
+    }
 
     @Override
-    public EmptyRepresentationModel toModel(@NonNull Application application) {
+    public EmptyRepresentationModel toModel(@NonNull Application application, @NonNull Context context) {
         var model = new EmptyRepresentationModel();
-        model.add(getSelfLink(application))
-                .add(getProfileLink(application));
-        application.getEntities().forEach(entity -> model.add(getEntityLink(application, entity)));
+        model.add(context.linkFactoryProvider().toRoot().withSelfRel())
+                .add(context.linkFactoryProvider().toProfileRoot().withRel(IanaLinkRelations.PROFILE));
+        for (var entity : application.getEntities()) {
+            model.add(context.linkFactoryProvider().toCollection(entity.getName(), CollectionParameters.defaults()).withRel(ContentGridLinkRelations.ENTITY));
+        }
         return model;
-    }
-
-    private Link getSelfLink(@NonNull Application application) {
-        return linkTo(methodOn(RootRestController.class).getRoot(application))
-                .withSelfRel();
-    }
-
-    private Link getEntityLink(@NonNull Application application, @NonNull Entity entity) {
-        return linkTo(methodOn(EntityRestController.class)
-                .listEntity(application, entity.getPathSegment(), null, MultiValueMap.fromSingleValue(Map.of()), null))
-                .withRel(ContentGridLinkRelations.ENTITY).expand()
-                .withName(entity.getLinkName().getValue());
-    }
-
-    private Link getProfileLink(@NonNull Application application) {
-        return linkTo(methodOn(ProfileRestController.class).getProfile(application))
-                .withRel(IanaLinkRelations.PROFILE);
     }
 }

--- a/contentgrid-appserver-rest/src/main/java/com/contentgrid/appserver/rest/assembler/profile/ProfileRootRepresentationModelAssembler.java
+++ b/contentgrid-appserver-rest/src/main/java/com/contentgrid/appserver/rest/assembler/profile/ProfileRootRepresentationModelAssembler.java
@@ -1,35 +1,34 @@
 package com.contentgrid.appserver.rest.assembler.profile;
 
-import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
-import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
-
 import com.contentgrid.appserver.application.model.Application;
-import com.contentgrid.appserver.application.model.Entity;
-import com.contentgrid.appserver.rest.ProfileRestController;
 import com.contentgrid.appserver.rest.assembler.EmptyRepresentationModel;
+import com.contentgrid.appserver.rest.assembler.profile.ProfileRootRepresentationModelAssembler.Context;
 import com.contentgrid.appserver.rest.links.ContentGridLinkRelations;
+import com.contentgrid.appserver.rest.links.factory.LinkFactoryProvider;
+import com.contentgrid.hateoas.spring.server.RepresentationModelContextAssembler;
 import lombok.NonNull;
-import org.springframework.hateoas.Link;
 import org.springframework.hateoas.server.RepresentationModelAssembler;
 
-public class ProfileRootRepresentationModelAssembler implements RepresentationModelAssembler<Application, EmptyRepresentationModel> {
+public class ProfileRootRepresentationModelAssembler implements
+        RepresentationModelContextAssembler<Application, EmptyRepresentationModel, Context> {
+
+    public RepresentationModelAssembler<Application, EmptyRepresentationModel> withContext(
+            LinkFactoryProvider linkFactoryProvider) {
+        return withContext(new Context(linkFactoryProvider));
+    }
+
+    public record Context(LinkFactoryProvider linkFactoryProvider) {
+
+    }
 
     @Override
-    public EmptyRepresentationModel toModel(@NonNull Application application) {
+    public EmptyRepresentationModel toModel(@NonNull Application application, Context context) {
         var result = new EmptyRepresentationModel();
-        result.add(getSelfLink(application));
-        application.getEntities().forEach(entity -> result.add(getEntityProfileLink(application, entity)));
+        result.add(context.linkFactoryProvider().toProfileRoot().withSelfRel());
+        for (var entity : application.getEntities()) {
+            result.add(context.linkFactoryProvider().toProfile(entity.getName()).withRel(ContentGridLinkRelations.ENTITY));
+        }
         return result;
     }
 
-    private Link getSelfLink(@NonNull Application application) {
-        return linkTo(methodOn(ProfileRestController.class).getProfile(application)).withSelfRel();
-    }
-
-    private Link getEntityProfileLink(@NonNull Application application, @NonNull Entity entity) {
-        return linkTo(methodOn(ProfileRestController.class)
-                .getHalFormsEntityProfile(application, entity.getPathSegment()))
-                .withRel(ContentGridLinkRelations.ENTITY)
-                .withName(entity.getLinkName().getValue());
-    }
 }

--- a/contentgrid-appserver-rest/src/main/java/com/contentgrid/appserver/rest/assembler/profile/hal/ProfileRelationRepresentationModelAssembler.java
+++ b/contentgrid-appserver-rest/src/main/java/com/contentgrid/appserver/rest/assembler/profile/hal/ProfileRelationRepresentationModelAssembler.java
@@ -1,24 +1,19 @@
 package com.contentgrid.appserver.rest.assembler.profile.hal;
 
-import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
-import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
-
-import com.contentgrid.appserver.application.model.Application;
 import com.contentgrid.appserver.application.model.relations.ManyToManyRelation;
 import com.contentgrid.appserver.application.model.relations.ManyToOneRelation;
 import com.contentgrid.appserver.application.model.relations.OneToManyRelation;
 import com.contentgrid.appserver.application.model.relations.Relation;
 import com.contentgrid.appserver.application.model.relations.flags.HiddenEndpointFlag;
-import com.contentgrid.appserver.rest.ProfileRestController;
 import com.contentgrid.appserver.rest.assembler.profile.BlueprintLinkRelations;
+import com.contentgrid.appserver.rest.assembler.profile.hal.ProfileEntityRepresentationModelAssembler.Context;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
-import org.springframework.hateoas.Link;
 
 @RequiredArgsConstructor
 public class ProfileRelationRepresentationModelAssembler {
 
-    public Optional<ProfileRelationRepresentationModel> toModel(Application application, Relation relation) {
+    public Optional<ProfileRelationRepresentationModel> toModel(Context context, Relation relation) {
         var sourceEndPoint = relation.getSourceEndPoint();
         if (sourceEndPoint.hasFlag(HiddenEndpointFlag.class)) {
             // ignore hidden endpoints
@@ -30,26 +25,24 @@ public class ProfileRelationRepresentationModelAssembler {
 
         var relationModel = ProfileRelationRepresentationModel.builder()
                 .name(sourceEndPoint.getName().getValue())
-                .title(readTitle(application, relation))
+                .title(readTitle(context, relation))
                 .description(sourceEndPoint.getDescription())
                 .manySourcePerTarget(isManySourcePerTarget)
                 .manyTargetPerSource(isManyTargetPerSource)
                 .required(sourceEndPoint.isRequired())
                 .build();
 
-        relationModel.add(getTargetProfileLink(application, relation));
+        relationModel.add(
+                context.linkFactoryProvider().toProfile(relation.getTargetEndPoint().getEntity())
+                        .withRel(BlueprintLinkRelations.TARGET_ENTITY)
+                        .withName(null)
+        );
 
         return Optional.of(relationModel);
     }
 
-    private String readTitle(Application application, Relation relation) {
+    private String readTitle(Context context, Relation relation) {
         return null; // TODO: resolve title (ACC-2230)
-    }
-
-    private Link getTargetProfileLink(Application application, Relation relation) {
-        return linkTo(methodOn(ProfileRestController.class)
-                .getHalFormsEntityProfile(application, application.getRelationTargetEntity(relation).getPathSegment()))
-                .withRel(BlueprintLinkRelations.TARGET_ENTITY);
     }
 
 }

--- a/contentgrid-appserver-rest/src/main/java/com/contentgrid/appserver/rest/data/conversion/StringDataEntryToRelationDataEntryConverter.java
+++ b/contentgrid-appserver-rest/src/main/java/com/contentgrid/appserver/rest/data/conversion/StringDataEntryToRelationDataEntryConverter.java
@@ -24,7 +24,7 @@ public class StringDataEntryToRelationDataEntryConverter implements Converter<St
         var value = source.getValue();
         var matcher = UriTemplateMatcher.<RelationDataEntry>builder()
                 .matcherFor(methodOn(EntityRestController.class)
-                                .getEntity(null, null, null, null),
+                                .getEntity(null, null, null, null, null),
                         params -> {
                             var entityPathSegment = params.get("entityName");
                             var entityId = params.get("instanceId");

--- a/contentgrid-appserver-rest/src/main/java/com/contentgrid/appserver/rest/exception/ContentGridExceptionHandler.java
+++ b/contentgrid-appserver-rest/src/main/java/com/contentgrid/appserver/rest/exception/ContentGridExceptionHandler.java
@@ -1,9 +1,5 @@
 package com.contentgrid.appserver.rest.exception;
 
-import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
-import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
-
-import com.contentgrid.appserver.application.model.Application;
 import com.contentgrid.appserver.domain.data.InvalidPropertyDataException;
 import com.contentgrid.appserver.domain.paging.cursor.CursorCodec.CursorDecodeException;
 import com.contentgrid.appserver.domain.values.version.ExactlyVersion;
@@ -11,11 +7,10 @@ import com.contentgrid.appserver.exception.InvalidSortParameterException;
 import com.contentgrid.appserver.query.engine.api.exception.BlindRelationOverwriteException;
 import com.contentgrid.appserver.query.engine.api.exception.PermissionDeniedException;
 import com.contentgrid.appserver.query.engine.api.exception.UnsatisfiedVersionException;
-import com.contentgrid.appserver.rest.EntityRestController;
+import com.contentgrid.appserver.rest.links.factory.LinkFactoryProvider;
 import com.contentgrid.appserver.rest.problem.ProblemFactory;
 import com.contentgrid.appserver.rest.problem.ProblemType;
 import com.contentgrid.appserver.rest.problem.ext.ConstraintViolationProblemProperties.FieldViolationProblemProperties;
-import com.contentgrid.appserver.rest.property.XToOneRelationRestController;
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import java.util.Map;
@@ -110,34 +105,15 @@ public class ContentGridExceptionHandler {
     }
 
     @ExceptionHandler(BlindRelationOverwriteException.class)
-    ResponseEntity<Problem> handleBlindRelationOverwrite(Application application, BlindRelationOverwriteException exception) {
+    ResponseEntity<Problem> handleBlindRelationOverwrite(BlindRelationOverwriteException exception, LinkFactoryProvider linkFactoryProvider) {
         return createResponse(
                 problemFactory.createProblem(ProblemType.INTEGRITY_RELATION_OVERWRITE)
                         .withStatus(HttpStatus.CONFLICT)
                         .withProperties(properties -> {
-                            var relationEntity = application.getRequiredEntityByName(exception.getAffectedRelation().getEntityName());
-                            var relation = application.getRequiredRelationForEntity(relationEntity, exception.getAffectedRelation().getRelationName());
-                            var affectedRelationLink = linkTo(methodOn(XToOneRelationRestController.class)
-                                            .getRelation(
-                                                    application,
-                                                    relationEntity.getPathSegment(),
-                                                    exception.getAffectedRelation().getEntityId(),
-                                                    relation.getSourceEndPoint().getPathSegment(),
-                                                    null
-                                            )).withSelfRel();
-
-                            var originalEntity = application.getRequiredEntityByName(exception.getOriginalValue().getEntityName());
-                            var originalEntityLink = linkTo(methodOn(EntityRestController.class)
-                                    .getEntity(
-                                            application,
-                                            originalEntity.getPathSegment(),
-                                            exception.getOriginalValue().getEntityId(),
-                                            null
-                                    )
-                            ).withSelfRel();
-
-                            properties.put("affected-relation", affectedRelationLink.getHref());
-                            properties.put("existing-item", originalEntityLink.getHref());
+                            var affectedRelationLink = linkFactoryProvider.toRelation(exception.getAffectedRelation()).toUri();
+                            var originalEntityLink = linkFactoryProvider.toItem(exception.getOriginalValue()).toUri();
+                            properties.put("affected-relation", affectedRelationLink.toString());
+                            properties.put("existing-item", originalEntityLink.toString());
                         })
         );
     }

--- a/contentgrid-appserver-rest/src/main/java/com/contentgrid/appserver/rest/hal/forms/HalFormsMediaTypeConfiguration.java
+++ b/contentgrid-appserver-rest/src/main/java/com/contentgrid/appserver/rest/hal/forms/HalFormsMediaTypeConfiguration.java
@@ -34,11 +34,6 @@ public class HalFormsMediaTypeConfiguration implements HypermediaMappingInformat
         return mapper;
     }
 
-    @Bean
-    public HalFormsTemplateGenerator halFormsTemplateGenerator() {
-        return new HalFormsTemplateGenerator();
-    }
-
     /**
      * Bean that customizes the {@link ObjectMapper} to only expose properties with the {@link DefaultView}.
      * Properties with a different view will be ignored.

--- a/contentgrid-appserver-rest/src/main/java/com/contentgrid/appserver/rest/links/factory/CustomizableLinkFactory.java
+++ b/contentgrid-appserver-rest/src/main/java/com/contentgrid/appserver/rest/links/factory/CustomizableLinkFactory.java
@@ -1,0 +1,15 @@
+package com.contentgrid.appserver.rest.links.factory;
+
+/**
+ * A {@link LinkFactory} that allows customizing attributes of the {@link org.springframework.hateoas.Link} that will
+ * be generated with a relation.
+ */
+public interface CustomizableLinkFactory extends LinkFactory {
+    CustomizableLinkFactory withName(String name);
+    CustomizableLinkFactory withTitle(String title);
+    CustomizableLinkFactory withType(String type);
+    CustomizableLinkFactory withProfile(String profile);
+    CustomizableLinkFactory withDeprecation(String deprecation);
+    CustomizableLinkFactory withHreflang(String name);
+
+}

--- a/contentgrid-appserver-rest/src/main/java/com/contentgrid/appserver/rest/links/factory/LinkBuilderAndModifiersLinkFactory.java
+++ b/contentgrid-appserver-rest/src/main/java/com/contentgrid/appserver/rest/links/factory/LinkBuilderAndModifiersLinkFactory.java
@@ -1,0 +1,79 @@
+package com.contentgrid.appserver.rest.links.factory;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.UnaryOperator;
+import lombok.AccessLevel;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.With;
+import org.springframework.hateoas.Link;
+import org.springframework.hateoas.LinkRelation;
+import org.springframework.hateoas.server.LinkBuilder;
+
+@RequiredArgsConstructor
+class LinkBuilderAndModifiersLinkFactory implements CustomizableLinkFactory {
+    @NonNull
+    private final LinkBuilder linkBuilder;
+
+    @With(value = AccessLevel.PRIVATE)
+    @NonNull
+    private final List<UnaryOperator<Link>> customizations;
+
+    LinkBuilderAndModifiersLinkFactory(@NonNull LinkBuilder linkBuilder) {
+        this(linkBuilder, List.of());
+    }
+
+    private LinkBuilderAndModifiersLinkFactory withCustomization(UnaryOperator<Link> customization) {
+        var copy = new ArrayList<>(customizations);
+        copy.add(customization);
+        return withCustomizations(copy);
+    }
+
+    @Override
+    public URI toUri() {
+        return linkBuilder.toUri();
+    }
+
+    @Override
+    public Link withRel(LinkRelation linkRelation) {
+        var link = linkBuilder.withRel(linkRelation);
+
+        for (var customization : customizations) {
+            link = customization.apply(link);
+        }
+
+        return link;
+    }
+
+    @Override
+    public CustomizableLinkFactory withName(String name) {
+        return withCustomization(l -> l.withName(name));
+    }
+
+    @Override
+    public CustomizableLinkFactory withTitle(String title) {
+        return withCustomization(l -> l.withTitle(title));
+    }
+
+    @Override
+    public CustomizableLinkFactory withType(String type) {
+        return withCustomization(l -> l.withType(type));
+    }
+
+    @Override
+    public CustomizableLinkFactory withProfile(String profile) {
+        return withCustomization(l -> l.withProfile(profile));
+    }
+
+    @Override
+    public CustomizableLinkFactory withDeprecation(String deprecation) {
+        return withCustomization(l -> l.withDeprecation(deprecation));
+    }
+
+    @Override
+    public CustomizableLinkFactory withHreflang(String name) {
+        return withCustomization(l -> l.withHreflang(name));
+    }
+}

--- a/contentgrid-appserver-rest/src/main/java/com/contentgrid/appserver/rest/links/factory/LinkFactory.java
+++ b/contentgrid-appserver-rest/src/main/java/com/contentgrid/appserver/rest/links/factory/LinkFactory.java
@@ -1,0 +1,47 @@
+package com.contentgrid.appserver.rest.links.factory;
+
+import java.net.URI;
+import org.springframework.hateoas.IanaLinkRelations;
+import org.springframework.hateoas.Link;
+import org.springframework.hateoas.LinkRelation;
+
+/**
+ * Factory for creating {@link Link}s with a certain {@link LinkRelation}
+ * @see CustomizableLinkFactory for customizing the parameters of the generated {@link Link}
+ */
+public interface LinkFactory {
+
+    /**
+     * Create a link with the attributes configured on this factory
+     *
+     * @param linkRelation The link relation to use for the link
+     * @return A new link
+     */
+    Link withRel(LinkRelation linkRelation);
+
+    /**
+     * @return The URI of the link that is built by this factory
+     */
+    default URI toUri() {
+        return withSelfRel().toUri();
+    }
+
+    /**
+     * Create a link with the <code>self</code> link relation. A <code>self</code>-link provides the link for the current page.
+     * <p>
+     * A <code>self</code>-link does not have most link attributes that would be present for other instances of the link.
+     * In particular, it does not duplicate information about the current page that is also provided in other ways, like via other links or HTTP headers.
+     * @return A new link
+     */
+    default Link withSelfRel() {
+        return withRel(IanaLinkRelations.SELF)
+                // Self-link should not have all these properties:
+                // The self-link describes the current page, so:
+                .withName(null) // name is not used for disambiguation
+                // But title is present; it is basically the human-readable title of this page
+                .withProfile(null) // profile is provided with a separate 'profile' link
+                .withType(null) // Content-Type is provided using HTTP headers
+                .withHreflang(null) // Language is negotiated using HTTP Headers
+                .withDeprecation(null); // Deprecation information about the page is provided using HTTP headers
+    }
+}

--- a/contentgrid-appserver-rest/src/main/java/com/contentgrid/appserver/rest/links/factory/LinkFactoryProvider.java
+++ b/contentgrid-appserver-rest/src/main/java/com/contentgrid/appserver/rest/links/factory/LinkFactoryProvider.java
@@ -1,0 +1,221 @@
+package com.contentgrid.appserver.rest.links.factory;
+
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
+
+import com.contentgrid.appserver.application.model.Application;
+import com.contentgrid.appserver.application.model.attributes.ContentAttribute;
+import com.contentgrid.appserver.application.model.exceptions.AttributeNotFoundException;
+import com.contentgrid.appserver.application.model.values.AttributeName;
+import com.contentgrid.appserver.application.model.values.EntityName;
+import com.contentgrid.appserver.domain.paging.cursor.EncodedCursorPagination;
+import com.contentgrid.appserver.domain.values.EntityId;
+import com.contentgrid.appserver.domain.values.EntityIdentity;
+import com.contentgrid.appserver.domain.values.RelationIdentity;
+import com.contentgrid.appserver.rest.EntityRestController;
+import com.contentgrid.appserver.rest.ProfileRestController;
+import com.contentgrid.appserver.rest.RootRestController;
+import com.contentgrid.appserver.rest.property.ContentRestController;
+import com.contentgrid.appserver.rest.property.XToOneRelationRestController;
+import com.contentgrid.hateoas.spring.links.UriTemplateMatcher;
+import java.util.List;
+import java.util.UUID;
+import java.util.function.Consumer;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.With;
+import org.springframework.hateoas.server.MethodLinkBuilderFactory;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+/**
+ * Generates {@link LinkFactory}s for entity-based paths
+ * <p>
+ * Allows an easy way to generate links to specific resources without having to specify
+ * all parameters for the controller method call.
+ */
+@RequiredArgsConstructor
+public class LinkFactoryProvider {
+    @NonNull
+    private final Application application;
+
+    @NonNull
+    private final MethodLinkBuilderFactory<?> linkBuilderFactory;
+
+    @With
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class CollectionParameters {
+
+        /**
+         * @return Default collection parameters (no search parameters and no cursor)
+         */
+        public static CollectionParameters defaults() {
+            return new CollectionParameters(new LinkedMultiValueMap<>(), null);
+        }
+
+        @NonNull
+        private final MultiValueMap<String, String> searchParams;
+
+        private final EncodedCursorPagination cursor;
+
+        public CollectionParameters withModifiedSearchParams(@NonNull Consumer<MultiValueMap<String, String>> modifier) {
+            var copy = new LinkedMultiValueMap<>(searchParams);
+            modifier.accept(copy);
+            return withSearchParams(copy);
+        }
+
+        public CollectionParameters withSearchParam(@NonNull String name, @NonNull String value) {
+            return withModifiedSearchParams(map -> map.set(name, value));
+        }
+
+        public CollectionParameters withSearchParam(@NonNull String name, @NonNull List<String> values) {
+            return withModifiedSearchParams(map -> map.put(name, values));
+        }
+    }
+
+    private CustomizableLinkFactory linkTo(Object invocationValue) {
+        var linkBuilder = linkBuilderFactory.linkTo(invocationValue);
+
+        return new LinkBuilderAndModifiersLinkFactory(linkBuilder);
+    }
+
+    /**
+     * Generate a link to the API root
+     * @return A link to the API root
+     */
+    public LinkFactory toRoot() {
+        return linkTo(methodOn(RootRestController.class).getRoot(application, this));
+    }
+
+    /**
+     * Generate a link to an entity collection
+     *
+     * @param entityName The entity to link to
+     * @param parameters Parameters for the collection request
+     * @return A link to the entity collection with the given parameters
+     */
+    public LinkFactory toCollection(@NonNull EntityName entityName, @NonNull CollectionParameters parameters) {
+        var entity = application.getRequiredEntityByName(entityName);
+        return linkTo(methodOn(EntityRestController.class)
+                .listEntity(
+                        application,
+                        entity.getPathSegment(),
+                        null,
+                        parameters.searchParams,
+                        parameters.cursor,
+                        this
+                ))
+                .withName(entity.getLinkName().getValue())
+                .withProfile(toProfile(entityName).toUri().toString());
+    }
+
+    /**
+     * Generate a link to an entity item
+     * @param identity The identity of the entity to link to
+     * @return A link to an entity item
+     */
+    public LinkFactory toItem(@NonNull EntityIdentity identity) {
+        var entity = application.getRequiredEntityByName(identity.getEntityName());
+        return linkTo(methodOn(EntityRestController.class)
+                .getEntity(
+                        application,
+                        entity.getPathSegment(),
+                        identity.getEntityId(),
+                        null,
+                        this
+                ))
+                .withProfile(toProfile(identity.getEntityName()).toUri().toString());
+    }
+
+    /**
+     * Generate a link matcher for an entity item
+     * @param entityName The entity to generate a matcher for
+     * @return Template matcher for an entity item of a particular type
+     */
+    public UriTemplateMatcher<EntityId> itemMatcher(@NonNull EntityName entityName) {
+        var entity = application.getRequiredEntityByName(entityName);
+
+        return UriTemplateMatcher.<EntityId>builder()
+                .matcherFor(methodOn(EntityRestController.class)
+                                .getEntity(application, entity.getPathSegment(), null, null, null),
+                        params -> EntityId.of(UUID.fromString(params.get("instanceId"))))
+                .build();
+    }
+
+    /**
+     * Generate a link for an entity relation
+     * @param relationIdentity The identity of the relation to link to
+     * @return A link to an entity relation
+     */
+    public LinkFactory toRelation(@NonNull RelationIdentity relationIdentity) {
+        var entity = application.getRequiredEntityByName(relationIdentity.getEntityName());
+        var relation = application.getRequiredRelationForEntity(entity, relationIdentity.getRelationName());
+
+        // Links for *-to-many relations are the same as links for *-to-one relations,
+        // no need to switch based on relation type
+        return linkTo(methodOn(XToOneRelationRestController.class)
+                .getRelation(
+                        application,
+                        entity.getPathSegment(),
+                        relationIdentity.getEntityId(),
+                        relation.getSourceEndPoint().getPathSegment(),
+                        null,
+                        this
+                ))
+                .withName(relation.getSourceEndPoint().getLinkName().getValue());
+    }
+
+    /**
+     * Generate a link for entity content
+     * @param identity The identity of the entity to link to
+     * @param attributeName The name of the content attribute
+     * @return A link to entity content
+     */
+    public LinkFactory toContent(@NonNull EntityIdentity identity, @NonNull AttributeName attributeName) {
+        var entity = application.getRequiredEntityByName(identity.getEntityName());
+        var attribute = entity.getAttributeByName(attributeName)
+                .filter(ContentAttribute.class::isInstance)
+                .map(ContentAttribute.class::cast)
+                .orElseThrow(() -> new AttributeNotFoundException("Entity '%s' does not have content attribute '%s'".formatted(entity.getName(), attributeName)));
+
+        return linkTo(methodOn(ContentRestController.class)
+                .getContent(
+                        null,
+                        application,
+                        entity.getPathSegment(),
+                        identity.getEntityId(),
+                        attribute.getPathSegment(),
+                        null,
+                        null,
+                        null
+                ))
+                .withName(attributeName.getValue());
+    }
+
+    /**
+     * Generate a link to the profile root
+     * @return A link to the profile root
+     */
+    public LinkFactory toProfileRoot() {
+        return linkTo(methodOn(ProfileRestController.class).getProfile(application, this));
+    }
+
+    /**
+     * Generate a link to an entity profile
+     *
+     * @param entityName The entity to link to the profile to
+     * @return A link to the entity profile
+     */
+    public LinkFactory toProfile(@NonNull EntityName entityName) {
+        var entity = application.getRequiredEntityByName(entityName);
+        return linkTo(methodOn(ProfileRestController.class)
+                .getHalFormsEntityProfile(
+                        application,
+                        entity.getPathSegment(),
+                        this
+                ))
+                .withName(entity.getLinkName().getValue());
+    }
+
+}


### PR DESCRIPTION
Using a single service to generate all links ensures that they get consistent attributes in all places, and also that future changes in controller parameters only require changes in this one place instead of everywhere where links get created