### PR TITLE
ACC-2312: Enable number in page metadata

### DIFF
--- a/contentgrid-appserver-domain/src/main/java/com/contentgrid/appserver/domain/DatamodelApiImpl.java
+++ b/contentgrid-appserver-domain/src/main/java/com/contentgrid/appserver/domain/DatamodelApiImpl.java
@@ -3,7 +3,6 @@ package com.contentgrid.appserver.domain;
 import com.contentgrid.appserver.application.model.Application;
 import com.contentgrid.appserver.application.model.Entity;
 import com.contentgrid.appserver.application.model.attributes.Attribute;
-import com.contentgrid.appserver.application.model.relations.Relation;
 import com.contentgrid.appserver.application.model.values.EntityName;
 import com.contentgrid.appserver.contentstore.api.ContentStore;
 import com.contentgrid.appserver.domain.authorization.AuthorizationContext;
@@ -42,7 +41,6 @@ import com.contentgrid.appserver.domain.values.EntityRequest;
 import com.contentgrid.appserver.domain.values.ItemCount;
 import com.contentgrid.appserver.domain.values.RelationIdentity;
 import com.contentgrid.appserver.domain.values.RelationRequest;
-import com.contentgrid.appserver.domain.values.version.Version;
 import com.contentgrid.appserver.exception.InvalidSortParameterException;
 import com.contentgrid.appserver.query.engine.api.QueryEngine;
 import com.contentgrid.appserver.query.engine.api.data.AttributeData;
@@ -54,7 +52,6 @@ import com.contentgrid.appserver.query.engine.api.data.SortData.FieldSort;
 import com.contentgrid.appserver.query.engine.api.exception.EntityIdNotFoundException;
 import com.contentgrid.appserver.query.engine.api.exception.InvalidThunkExpressionException;
 import com.contentgrid.appserver.query.engine.api.exception.QueryEngineException;
-import com.contentgrid.hateoas.pagination.api.PaginationControls;
 import com.contentgrid.thunx.predicates.model.LogicalOperation;
 import com.contentgrid.thunx.predicates.model.ThunkExpression;
 import java.time.Clock;
@@ -153,8 +150,7 @@ public class DatamodelApiImpl implements DatamodelApi {
         var result = queryEngine.findAll(application, entity, fullFilter, sort, page);
         var hasNext = result.getEntities().size() > offsetData.getLimit();
 
-        PaginationControls controls = EncodedCursorSupport.makeControls(cursorCodec, pagination, entity.getName(),
-                params, hasNext);
+        var controls = EncodedCursorSupport.makeControls(cursorCodec, pagination, entity.getName(), params, hasNext);
 
         // Get a total count of how many items match these params
         var count = calculateCount(() -> queryEngine.count(application, entity, fullFilter),

--- a/contentgrid-appserver-domain/src/main/java/com/contentgrid/appserver/domain/paging/OriginalPaginationAccessor.java
+++ b/contentgrid-appserver-domain/src/main/java/com/contentgrid/appserver/domain/paging/OriginalPaginationAccessor.java
@@ -1,0 +1,9 @@
+package com.contentgrid.appserver.domain.paging;
+
+import com.contentgrid.hateoas.pagination.api.Pagination;
+
+public interface OriginalPaginationAccessor {
+
+    Pagination originalPagination();
+
+}

--- a/contentgrid-appserver-domain/src/main/java/com/contentgrid/appserver/domain/paging/PageBasedPaginationControls.java
+++ b/contentgrid-appserver-domain/src/main/java/com/contentgrid/appserver/domain/paging/PageBasedPaginationControls.java
@@ -1,0 +1,57 @@
+package com.contentgrid.appserver.domain.paging;
+
+import com.contentgrid.hateoas.pagination.api.Pagination;
+import com.contentgrid.hateoas.pagination.api.PaginationControls;
+import java.util.Optional;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.Accessors;
+
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class PageBasedPaginationControls implements PaginationControls {
+
+    @Getter
+    private final int size;
+    @Getter
+    private final int page;
+
+    @Getter
+    @Accessors(fluent = true)
+    private final boolean hasNext;
+
+    public static PageBasedPaginationControls forPagination(PageBasedPagination pagination, boolean hasNext) {
+        return new PageBasedPaginationControls(pagination.getSize(), pagination.getPage(), hasNext);
+    }
+
+    @Override
+    public Pagination current() {
+        return new PageBasedPagination(size, page);
+    }
+
+    @Override
+    public Optional<Pagination> next() {
+        if (!hasNext()) {
+            return Optional.empty();
+        }
+        return Optional.of(new PageBasedPagination(size, page + 1));
+    }
+
+    @Override
+    public boolean hasPrevious() {
+        return page > 0;
+    }
+
+    @Override
+    public Optional<Pagination> previous() {
+        if (!hasPrevious()) {
+            return Optional.empty();
+        }
+        return Optional.of(new PageBasedPagination(size, page - 1));
+    }
+
+    @Override
+    public Pagination first() {
+        return new PageBasedPagination(size, 0);
+    }
+}

--- a/contentgrid-appserver-domain/src/main/java/com/contentgrid/appserver/domain/paging/ResultSlice.java
+++ b/contentgrid-appserver-domain/src/main/java/com/contentgrid/appserver/domain/paging/ResultSlice.java
@@ -1,9 +1,9 @@
 package com.contentgrid.appserver.domain.paging;
 
 import com.contentgrid.appserver.domain.data.EntityInstance;
+import com.contentgrid.appserver.domain.paging.cursor.EncodedCursorPaginationControls;
 import com.contentgrid.appserver.domain.values.ItemCount;
 import com.contentgrid.hateoas.pagination.api.Pagination;
-import com.contentgrid.hateoas.pagination.api.PaginationControls;
 import com.contentgrid.hateoas.pagination.api.Slice;
 import java.util.List;
 import java.util.Optional;
@@ -11,10 +11,10 @@ import lombok.NonNull;
 import lombok.Value;
 
 @Value
-public class ResultSlice implements Slice<EntityInstance> {
+public class ResultSlice implements Slice<EntityInstance>, OriginalPaginationAccessor {
     List<? extends EntityInstance> entities;
 
-    PaginationControls controls;
+    EncodedCursorPaginationControls controls;
 
     @NonNull
     ItemCount totalItemCount;
@@ -32,6 +32,11 @@ public class ResultSlice implements Slice<EntityInstance> {
     @Override
     public Pagination current() {
         return controls.current();
+    }
+
+    @Override
+    public Pagination originalPagination() {
+        return controls.originalPagination();
     }
 
     @Override

--- a/contentgrid-appserver-domain/src/main/java/com/contentgrid/appserver/domain/paging/cursor/EncodedCursorPaginationControls.java
+++ b/contentgrid-appserver-domain/src/main/java/com/contentgrid/appserver/domain/paging/cursor/EncodedCursorPaginationControls.java
@@ -1,5 +1,6 @@
 package com.contentgrid.appserver.domain.paging.cursor;
 
+import com.contentgrid.appserver.domain.paging.OriginalPaginationAccessor;
 import com.contentgrid.hateoas.pagination.api.Pagination;
 import com.contentgrid.hateoas.pagination.api.PaginationControls;
 import java.util.Optional;
@@ -8,7 +9,7 @@ import lombok.NonNull;
 import lombok.Value;
 
 @Value
-public class EncodedCursorPaginationControls implements PaginationControls {
+public class EncodedCursorPaginationControls implements PaginationControls, OriginalPaginationAccessor {
 
     @NonNull
     PaginationControls delegate;
@@ -19,6 +20,11 @@ public class EncodedCursorPaginationControls implements PaginationControls {
     @Override
     public Pagination current() {
         return encoder.apply(delegate.current());
+    }
+
+    @Override
+    public Pagination originalPagination() {
+        return delegate.current();
     }
 
     @Override

--- a/contentgrid-appserver-domain/src/main/java/com/contentgrid/appserver/domain/paging/cursor/EncodedCursorPaginationControls.java
+++ b/contentgrid-appserver-domain/src/main/java/com/contentgrid/appserver/domain/paging/cursor/EncodedCursorPaginationControls.java
@@ -3,6 +3,7 @@ package com.contentgrid.appserver.domain.paging.cursor;
 import com.contentgrid.hateoas.pagination.api.Pagination;
 import com.contentgrid.hateoas.pagination.api.PaginationControls;
 import java.util.Optional;
+import java.util.function.Function;
 import lombok.NonNull;
 import lombok.Value;
 
@@ -10,31 +11,38 @@ import lombok.Value;
 public class EncodedCursorPaginationControls implements PaginationControls {
 
     @NonNull
-    EncodedCursorPagination pagination;
-
-    EncodedCursorPagination next;
-    EncodedCursorPagination previous;
+    PaginationControls delegate;
 
     @NonNull
-    EncodedCursorPagination first;
+    Function<Pagination, EncodedCursorPagination> encoder;
 
     @Override
     public Pagination current() {
-        return pagination;
+        return encoder.apply(delegate.current());
+    }
+
+    @Override
+    public boolean hasNext() {
+        return delegate.hasNext();
     }
 
     @Override
     public Optional<Pagination> next() {
-        return Optional.ofNullable(this.next);
+        return delegate.next().map(encoder);
+    }
+
+    @Override
+    public boolean hasPrevious() {
+        return delegate.hasPrevious();
     }
 
     @Override
     public Optional<Pagination> previous() {
-        return Optional.ofNullable(this.previous);
+        return delegate.previous().map(encoder);
     }
 
     @Override
     public Pagination first() {
-        return first;
+        return encoder.apply(delegate.first());
     }
 }

--- a/contentgrid-appserver-domain/src/main/java/com/contentgrid/appserver/domain/paging/cursor/EncodedCursorSupport.java
+++ b/contentgrid-appserver-domain/src/main/java/com/contentgrid/appserver/domain/paging/cursor/EncodedCursorSupport.java
@@ -3,7 +3,6 @@ package com.contentgrid.appserver.domain.paging.cursor;
 import com.contentgrid.appserver.application.model.values.EntityName;
 import com.contentgrid.appserver.domain.paging.PageBasedPagination;
 import com.contentgrid.appserver.domain.paging.PageBasedPaginationControls;
-import com.contentgrid.hateoas.pagination.api.PaginationControls;
 import java.util.List;
 import java.util.Map;
 import lombok.NonNull;
@@ -11,7 +10,7 @@ import lombok.experimental.UtilityClass;
 
 @UtilityClass
 public class EncodedCursorSupport {
-    public static PaginationControls makeControls(
+    public static EncodedCursorPaginationControls makeControls(
             @NonNull CursorCodec codec,
             @NonNull EncodedCursorPagination pagination,
             @NonNull EntityName entity,

--- a/contentgrid-appserver-domain/src/main/java/com/contentgrid/appserver/domain/paging/cursor/EncodedCursorSupport.java
+++ b/contentgrid-appserver-domain/src/main/java/com/contentgrid/appserver/domain/paging/cursor/EncodedCursorSupport.java
@@ -2,6 +2,7 @@ package com.contentgrid.appserver.domain.paging.cursor;
 
 import com.contentgrid.appserver.application.model.values.EntityName;
 import com.contentgrid.appserver.domain.paging.PageBasedPagination;
+import com.contentgrid.appserver.domain.paging.PageBasedPaginationControls;
 import com.contentgrid.hateoas.pagination.api.PaginationControls;
 import java.util.List;
 import java.util.Map;
@@ -19,17 +20,10 @@ public class EncodedCursorSupport {
     ) {
         var currentPage = (PageBasedPagination)
                 codec.decodeCursor(pagination.getCursorContext(), entity, params);
-        var current = codec.encodeCursor(currentPage, entity, pagination.getSort(), params).cursor();
-        var nextPage = new PageBasedPagination(currentPage.getSize(), currentPage.getPage() + 1);
-        var next = hasNext ? codec.encodeCursor(nextPage, entity, pagination.getSort(), params).cursor() : null;
-        var prevPage = new PageBasedPagination(currentPage.getSize(), currentPage.getPage() - 1);
-        var prev = currentPage.isFirstPage() ? null : codec.encodeCursor(prevPage, entity, pagination.getSort(), params).cursor();
-        var first = codec.encodeCursor(new PageBasedPagination(currentPage.getSize(), 0), entity, pagination.getSort(), params).cursor();
-        return new EncodedCursorPaginationControls(
-                new EncodedCursorPagination(current, currentPage.getSize(), pagination.getSort()),
-                next == null ? null : new EncodedCursorPagination(next, currentPage.getSize(), pagination.getSort()),
-                prev == null ? null : new EncodedCursorPagination(prev, currentPage.getSize(), pagination.getSort()),
-                new EncodedCursorPagination(first, currentPage.getSize(), pagination.getSort())
-        );
+        var paginationControls = PageBasedPaginationControls.forPagination(currentPage, hasNext);
+        return new EncodedCursorPaginationControls(paginationControls, page -> {
+            var context = codec.encodeCursor(page, entity, pagination.getSort(), params);
+            return new EncodedCursorPagination(context.cursor(), context.pageSize(), context.sort());
+        });
     }
 }

--- a/contentgrid-appserver-domain/src/test/java/com/contentgrid/appserver/domain/DatamodelApiImplTest.java
+++ b/contentgrid-appserver-domain/src/test/java/com/contentgrid/appserver/domain/DatamodelApiImplTest.java
@@ -34,7 +34,6 @@ import com.contentgrid.appserver.domain.data.validation.RequiredConstraintViolat
 import com.contentgrid.appserver.domain.values.ItemCount;
 import com.contentgrid.appserver.domain.paging.PageBasedPagination;
 import com.contentgrid.appserver.domain.paging.cursor.CursorCodec;
-import com.contentgrid.appserver.domain.paging.cursor.CursorCodec.CursorContext;
 import com.contentgrid.appserver.domain.paging.cursor.EncodedCursorPagination;
 import com.contentgrid.appserver.domain.paging.cursor.RequestIntegrityCheckCursorCodec;
 import com.contentgrid.appserver.domain.paging.cursor.SimplePageBasedCursorCodec;
@@ -59,7 +58,6 @@ import com.contentgrid.appserver.query.engine.api.data.XToManyRelationData;
 import com.contentgrid.appserver.query.engine.api.data.XToOneRelationData;
 import com.contentgrid.appserver.query.engine.api.exception.EntityIdNotFoundException;
 import com.contentgrid.appserver.query.engine.api.thunx.expression.StringComparison;
-import com.contentgrid.hateoas.pagination.api.Pagination;
 import com.contentgrid.thunx.predicates.model.LogicalOperation;
 import com.contentgrid.thunx.predicates.model.Scalar;
 import com.contentgrid.thunx.predicates.model.SymbolicReference;
@@ -1534,17 +1532,10 @@ class DatamodelApiImplTest {
                 stubNeeded = false;
             }
 
-            // Setup mock for encoding/decoding fake cursors
+            // Setup mock for decoding fake cursors
             Mockito.doReturn(new PageBasedPagination(size, page))
                     .when(codec)
                     .decodeCursor(any(), any(), any());
-            ArgumentCaptor<Pagination> paginationArg = ArgumentCaptor.forClass(Pagination.class);
-
-            Mockito.doAnswer(invocation -> {
-                var pagination = (PageBasedPagination) paginationArg.getValue();
-                var cursor = fakeCursor(pagination.getPage());
-                return new CursorContext(cursor, size, SortData.unsorted());
-            }).when(codec).encodeCursor(paginationArg.capture(), any(), any(), any());
 
             // mock queryEngine
             ArgumentCaptor<QueryPageData> pageArg = ArgumentCaptor.forClass(QueryPageData.class);

--- a/contentgrid-appserver-rest/src/main/java/com/contentgrid/appserver/rest/paging/CursorPageMetadata.java
+++ b/contentgrid-appserver-rest/src/main/java/com/contentgrid/appserver/rest/paging/CursorPageMetadata.java
@@ -1,13 +1,9 @@
 package com.contentgrid.appserver.rest.paging;
 
-import lombok.NonNull;
 import lombok.Value;
 
 @Value
 public class CursorPageMetadata {
-
-    @NonNull
-    String cursor;
 
     String previousCursor;
 

--- a/contentgrid-appserver-rest/src/main/java/com/contentgrid/appserver/rest/paging/ItemCountPageMetadata.java
+++ b/contentgrid-appserver-rest/src/main/java/com/contentgrid/appserver/rest/paging/ItemCountPageMetadata.java
@@ -10,7 +10,7 @@ import lombok.NonNull;
 import org.springframework.hateoas.PagedModel.PageMetadata;
 
 @EqualsAndHashCode(callSuper = true)
-@JsonIgnoreProperties({"number", "totalElements", "totalPages"})
+@JsonIgnoreProperties({"totalElements", "totalPages"})
 public class ItemCountPageMetadata extends PageMetadata {
 
     @NonNull
@@ -42,10 +42,6 @@ public class ItemCountPageMetadata extends PageMetadata {
         }
 
         return null;
-    }
-
-    public String getCursor() {
-        return cursorPageMetadata.getCursor();
     }
 
     @JsonProperty("prev_cursor")

--- a/contentgrid-appserver-rest/src/test/java/com/contentgrid/appserver/rest/EntityRestControllerTest.java
+++ b/contentgrid-appserver-rest/src/test/java/com/contentgrid/appserver/rest/EntityRestControllerTest.java
@@ -699,13 +699,12 @@ class EntityRestControllerTest {
 
                     // Check pagination metadata
                     .andExpect(jsonPath("$.page.size", is(20)))
-                    .andExpect(jsonPath("$.page.cursor").exists())
+                    .andExpect(jsonPath("$.page.number", is(0)))
                     .andExpect(jsonPath("$.page.prev_cursor").doesNotExist())
                     .andExpect(jsonPath("$.page.next_cursor").exists())
                     .andExpect(jsonPath("$.page.total_items_estimate", is(100)))
                     .andExpect(jsonPath("$.page.total_items_exact", is(100)))
                     // Check legacy properties don't exist
-                    .andExpect(jsonPath("$.page.number").doesNotExist())
                     .andExpect(jsonPath("$.page.totalElements").doesNotExist())
                     .andExpect(jsonPath("$.page.totalPages").doesNotExist())
                     .andReturn()
@@ -759,13 +758,12 @@ class EntityRestControllerTest {
 
                     // Check pagination metadata
                     .andExpect(jsonPath("$.page.size", is(10)))
-                    .andExpect(jsonPath("$.page.cursor").exists())
+                    .andExpect(jsonPath("$.page.number", is(1)))
                     .andExpect(jsonPath("$.page.prev_cursor").exists())
                     .andExpect(jsonPath("$.page.next_cursor").exists())
                     .andExpect(jsonPath("$.page.total_items_estimate", is(100)))
                     .andExpect(jsonPath("$.page.total_items_exact", is(100)))
                     // Check legacy properties don't exist
-                    .andExpect(jsonPath("$.page.number").doesNotExist())
                     .andExpect(jsonPath("$.page.totalElements").doesNotExist())
                     .andExpect(jsonPath("$.page.totalPages").doesNotExist())
 


### PR DESCRIPTION
- Add `PageBasedPaginationControls`
- Use a delegate in `EncodedCursorPaginationControls`
- Let `EncodedCursorPaginationControls` and `ResultSlice` implement `OriginalPaginationAccessor`, it has a method which returns the original pagination instead of the encoded pagination.
- Let EntityDataRepresentationModelAssembler use the original pagination to fill in the number in page metadata (and remove cursor from page metadata).