### PR TITLE
ACC-2763: Pin tag of S3MockContainer in tests to the version of com.adobe.testing:s3mock-testcontainers

### DIFF
--- a/contentgrid-appserver-contentstore-impl-s3/src/test/java/com/contentgrid/appserver/contentstore/impl/s3/S3ContentStoreWriteFailureTest.java
+++ b/contentgrid-appserver-contentstore-impl-s3/src/test/java/com/contentgrid/appserver/contentstore/impl/s3/S3ContentStoreWriteFailureTest.java
@@ -2,7 +2,9 @@ package com.contentgrid.appserver.contentstore.impl.s3;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.adobe.testing.s3mock.testcontainers.S3MockContainer;
 import com.contentgrid.appserver.contentstore.api.UnwritableContentException;
+import com.contentgrid.appserver.contentstore.impl.utils.testing.S3MockUtils;
 import io.minio.MakeBucketArgs;
 import io.minio.MinioAsyncClient;
 import io.minio.RemoveBucketArgs;
@@ -14,7 +16,6 @@ import java.util.UUID;
 import java.util.concurrent.CompletionException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import com.adobe.testing.s3mock.testcontainers.S3MockContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
@@ -34,7 +35,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 class S3ContentStoreWriteFailureTest {
 
     @Container
-    private static final S3MockContainer s3MockContainer = new S3MockContainer("latest");
+    private static final S3MockContainer s3MockContainer = new S3MockContainer(S3MockUtils.S3_MOCK_VERSION);
 
     private MinioAsyncClient client;
 

--- a/contentgrid-appserver-contentstore-impl-s3/src/test/java/com/contentgrid/appserver/contentstore/impl/s3/S3MockContentStoreTest.java
+++ b/contentgrid-appserver-contentstore-impl-s3/src/test/java/com/contentgrid/appserver/contentstore/impl/s3/S3MockContentStoreTest.java
@@ -1,6 +1,7 @@
 package com.contentgrid.appserver.contentstore.impl.s3;
 
 import com.adobe.testing.s3mock.testcontainers.S3MockContainer;
+import com.contentgrid.appserver.contentstore.impl.utils.testing.S3MockUtils;
 import io.minio.MinioAsyncClient;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -9,7 +10,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 class S3MockContentStoreTest extends AbstractS3ContentStoreTest {
 
     @Container
-    private static final S3MockContainer s3MockContainer = new S3MockContainer("latest");
+    private static final S3MockContainer s3MockContainer = new S3MockContainer(S3MockUtils.S3_MOCK_VERSION);
 
     @Override
     protected MinioAsyncClient createClient() {

--- a/contentgrid-appserver-contentstore-impl-utils/build.gradle
+++ b/contentgrid-appserver-contentstore-impl-utils/build.gradle
@@ -11,6 +11,7 @@ dependencies {
     testImplementation 'commons-io:commons-io:2.21.0'
 
     testFixturesImplementation 'org.junit.jupiter:junit-jupiter'
+    testFixturesImplementation 'com.adobe.testing:s3mock-testcontainers'
     testFixturesImplementation project(':contentgrid-appserver-contentstore-impl-fs')
 }
 

--- a/contentgrid-appserver-contentstore-impl-utils/src/testFixtures/java/com/contentgrid/appserver/contentstore/impl/utils/testing/S3MockUtils.java
+++ b/contentgrid-appserver-contentstore-impl-utils/src/testFixtures/java/com/contentgrid/appserver/contentstore/impl/utils/testing/S3MockUtils.java
@@ -1,0 +1,29 @@
+package com.contentgrid.appserver.contentstore.impl.utils.testing;
+
+import com.adobe.testing.s3mock.testcontainers.S3MockContainer;
+import java.io.IOException;
+import java.util.Properties;
+import lombok.experimental.UtilityClass;
+
+/**
+ * Tag used in {@link S3MockContainer} must match the version of the com.adobe.testing:s3mock-testcontainers.
+ */
+@UtilityClass
+public class S3MockUtils {
+
+    public static final String S3_MOCK_VERSION;
+
+    static {
+        // Read the version of com.adobe.testing:s3mock-testcontainers by looking at pom.properties
+        // of the published Maven package. When Renovate updates the version in build.gradle,
+        // the tests will automatically use the new version.
+        var props = new Properties();
+        try (var is = S3MockContainer.class.getResourceAsStream(
+                "/META-INF/maven/com.adobe.testing/s3mock-testcontainers/pom.properties")) {
+            props.load(is);
+            S3_MOCK_VERSION = props.getProperty("version");
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/contentgrid-appserver-integration-test/build.gradle
+++ b/contentgrid-appserver-integration-test/build.gradle
@@ -20,6 +20,7 @@ dependencies {
     // should not be used for most integration tests, but relevant for encryption compatibility
     testImplementation project(':contentgrid-appserver-contentstore-impl-encryption')
     testImplementation testFixtures(project(':contentgrid-appserver-rest'))
+    testImplementation testFixtures(project(':contentgrid-appserver-contentstore-impl-utils'))
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.boot:spring-boot-starter-web'

--- a/contentgrid-appserver-integration-test/src/test/java/com/contentgrid/appserver/integration/test/fixture/invoicing/InvoicingApiApplicationTest.java
+++ b/contentgrid-appserver-integration-test/src/test/java/com/contentgrid/appserver/integration/test/fixture/invoicing/InvoicingApiApplicationTest.java
@@ -17,6 +17,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.contentgrid.appserver.contentstore.impl.utils.testing.S3MockUtils;
 import com.contentgrid.appserver.domain.ContentApi.Content;
 import com.contentgrid.appserver.domain.data.DataEntry.BooleanDataEntry;
 import com.contentgrid.appserver.domain.data.DataEntry.NullDataEntry;
@@ -48,7 +49,6 @@ import org.hamcrest.Matcher;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -119,7 +119,7 @@ class InvoicingApiApplicationTest {
     PlatformTransactionManager transactionManager;
 
     @Container
-    static S3MockContainer s3MockContainer = new S3MockContainer("latest")
+    static S3MockContainer s3MockContainer = new S3MockContainer(S3MockUtils.S3_MOCK_VERSION)
             .withInitialBuckets(BUCKET_NAME);
 
     @DynamicPropertySource


### PR DESCRIPTION
Read the version of com.adobe.testing:s3mock-testcontainers by looking at pom.properties of the published Maven package. When Renovate updates the version in build.gradle, the tests will automatically use the new version.