### PR TITLE
ACC-1163: Add support for regex constraint (generic & specifically for content mimetype)

### DIFF
--- a/contentgrid-appserver-application-model/build.gradle
+++ b/contentgrid-appserver-application-model/build.gradle
@@ -7,4 +7,5 @@ plugins {
 
 dependencies {
     testImplementation 'org.assertj:assertj-core'
+    testImplementation 'org.springframework:spring-web'
 }

--- a/contentgrid-appserver-application-model/src/main/java/com/contentgrid/appserver/application/model/Constraint.java
+++ b/contentgrid-appserver-application-model/src/main/java/com/contentgrid/appserver/application/model/Constraint.java
@@ -3,11 +3,14 @@ package com.contentgrid.appserver.application.model;
 import com.contentgrid.appserver.application.model.exceptions.InvalidConstraintException;
 import java.util.List;
 import java.util.Set;
+import java.util.regex.Pattern;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.Value;
+import lombok.With;
 
 /**
  * Represents a constraint that can be applied to an attribute.
@@ -44,6 +47,16 @@ public sealed interface Constraint {
      */
     static AllowedValuesConstraint allowedValues(List<String> values) {
         return new AllowedValuesConstraint(values);
+    }
+
+    /**
+     * Creates a new regex constraint
+     * @param pattern the pattern that the attribute value must match
+     * @return a new RegexPatternConstraint instance
+     * @throws InvalidConstraintException if the pattern is not valid
+     */
+    static RegexPatternConstraint pattern(String pattern) {
+        return new RegexPatternConstraint(pattern);
     }
 
     /**
@@ -88,6 +101,34 @@ public sealed interface Constraint {
     @EqualsAndHashCode
     @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
     final class UniqueConstraint implements Constraint {
+
+    }
+
+    /**
+     * A constraint that restricts an attribute's value to match a regex.
+     */
+    @Value
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    class RegexPatternConstraint implements Constraint {
+        @NonNull
+        Pattern pattern;
+
+        @With
+        String htmlPattern;
+
+        private RegexPatternConstraint(@NonNull String pattern) {
+            this(tryCompile(pattern), pattern);
+        }
+
+        private static @NonNull Pattern tryCompile(@NonNull String pattern) {
+            try{
+                return Pattern.compile(pattern);
+            } catch(IllegalArgumentException e) {
+                var exception = new InvalidConstraintException("Regex is invalid: "+e.getMessage());
+                exception.initCause(e);
+                throw exception;
+            }
+        }
 
     }
 }

--- a/contentgrid-appserver-application-model/src/main/java/com/contentgrid/appserver/application/model/attributes/ContentAttribute.java
+++ b/contentgrid-appserver-application-model/src/main/java/com/contentgrid/appserver/application/model/attributes/ContentAttribute.java
@@ -18,6 +18,7 @@ import com.contentgrid.appserver.application.model.values.PathSegmentName;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -225,6 +226,19 @@ public class ContentAttribute implements CompositeAttribute {
                         .filter(Predicate.not(ABNFCharRange::isEmpty))
                         .map(ABNFCharRange::toRegexCharacterClass)
                         .collect(Collectors.joining());
+            }
+
+            @Override
+            public boolean equals(Object o) {
+                if (!(o instanceof ABNFCharCompositeRange that)) {
+                    return false;
+                }
+                return Objects.deepEquals(ranges, that.ranges);
+            }
+
+            @Override
+            public int hashCode() {
+                return Arrays.hashCode(ranges);
             }
 
             @Override

--- a/contentgrid-appserver-application-model/src/main/java/com/contentgrid/appserver/application/model/attributes/ContentAttribute.java
+++ b/contentgrid-appserver-application-model/src/main/java/com/contentgrid/appserver/application/model/attributes/ContentAttribute.java
@@ -1,5 +1,7 @@
 package com.contentgrid.appserver.application.model.attributes;
 
+import com.contentgrid.appserver.application.model.Constraint;
+import com.contentgrid.appserver.application.model.Constraint.RegexPatternConstraint;
 import com.contentgrid.appserver.application.model.attributes.SimpleAttribute.Type;
 import com.contentgrid.appserver.application.model.attributes.flags.AttributeFlag;
 import com.contentgrid.appserver.application.model.attributes.flags.IgnoredFlag;
@@ -13,9 +15,11 @@ import com.contentgrid.appserver.application.model.values.AttributeName;
 import com.contentgrid.appserver.application.model.values.ColumnName;
 import com.contentgrid.appserver.application.model.values.LinkName;
 import com.contentgrid.appserver.application.model.values.PathSegmentName;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.AccessLevel;
@@ -29,6 +33,9 @@ import lombok.experimental.Delegate;
 
 @Value
 public class ContentAttribute implements CompositeAttribute {
+
+    // package-private for testing
+    static final RegexPatternConstraint MIMETYPE_PATTERN_CONSTRAINT = Constraint.pattern(MediaTypeABNF.MEDIA_TYPE);
 
     @NonNull
     AttributeName name;
@@ -95,7 +102,9 @@ public class ContentAttribute implements CompositeAttribute {
                 .type(Type.TEXT).build();
         this.mimetype = SimpleAttribute.builder().name(AttributeName.of("mimetype")).column(mimetypeColumn)
                 .translations(resourceBundleTranslations.withPrefix("mimetype.").asConfigurable())
-                .type(Type.TEXT).build();
+                .type(Type.TEXT)
+                .constraint(MIMETYPE_PATTERN_CONSTRAINT)
+                .build();
         this.length = SimpleAttribute.builder().name(AttributeName.of("length")).column(lengthColumn)
                 .translations(resourceBundleTranslations.withPrefix("length.").asConfigurable())
                 .type(Type.LONG)
@@ -127,5 +136,136 @@ public class ContentAttribute implements CompositeAttribute {
             return translationsBy(Locale.ROOT, t -> t.withDescription(description));
         }
 
+    }
+
+    /**
+     * Constructs the media-type validation regex based on RFC9110 ABNF definitions
+     */
+    private static class MediaTypeABNF {
+        // https://www.rfc-editor.org/rfc/rfc5234#appendix-B.1
+        private static final ABNFCharRange DQUOTE = ABNFCharRange.of(0x22);
+        private static final ABNFCharRange HTAB = ABNFCharRange.of(0x09);
+        private static final ABNFCharRange SP = ABNFCharRange.of(0x20);
+        private static final ABNFCharRange VCHAR = ABNFCharRange.range(0x21, 0x7e);
+        private static final ABNFCharRange DIGIT = ABNFCharRange.range(0x30, 0x39);
+        private static final ABNFCharRange ALPHA = new ABNFCharCompositeRange(
+                ABNFCharRange.range(0x41, 0x5A),
+                ABNFCharRange.range(0x61, 0x7A)
+        );
+
+        // https://www.rfc-editor.org/rfc/rfc9110.html#name-field-values
+        private static final ABNFCharRange OBS_TEXT = ABNFCharRange.range(0x80, 0xff);
+
+        // https://www.rfc-editor.org/rfc/rfc9110.html#name-tokens
+        private static final ABNFCharRange TCHAR = new ABNFCharCompositeRange(
+                ABNFCharRange.of('!', '#', '$', '%', '&', '*', '+', '-', '.', '^', '_', '`', '|', '~'),
+                DIGIT,
+                ALPHA
+        );
+        private static final String TOKEN = TCHAR+"+";
+
+        // https://www.rfc-editor.org/rfc/rfc9110.html#name-whitespace
+        private static final String OWS = new ABNFCharCompositeRange(SP, HTAB)+"*";
+
+        // https://www.rfc-editor.org/rfc/rfc9110.html#name-quoted-strings
+        private static final ABNFCharRange QDTEXT = new ABNFCharCompositeRange(HTAB, SP, ABNFCharRange.of(0x21), ABNFCharRange.range(0x23, 0x5B), ABNFCharRange.range(0x5D, 0x7E), OBS_TEXT);
+        private static final String QUOTED_PAIR = "(?:"+ABNFCharRange.of('\\')+new ABNFCharCompositeRange(HTAB, SP, VCHAR, OBS_TEXT)+")";
+
+        private static final String QUOTED_STRING = "(?:"+DQUOTE + "(?:"+QDTEXT +"|"+QUOTED_PAIR+")*"+DQUOTE+")";
+
+        // https://www.rfc-editor.org/rfc/rfc9110.html#parameter
+        private static final String PARAMETER_NAME = TOKEN;
+        private static final String PARAMETER_VALUE = "(?:"+TOKEN+"|"+QUOTED_STRING+")";
+        private static final String PARAMETER = PARAMETER_NAME+ABNFCharRange.of('=')+PARAMETER_VALUE;
+        private static final String PARAMETERS = "(?:"+OWS+ABNFCharRange.of(';')+OWS+"(?:"+PARAMETER+")?)*";
+
+        //  https://www.rfc-editor.org/rfc/rfc9110.html#name-media-type
+        public static final String MEDIA_TYPE = TOKEN+"/"+TOKEN+PARAMETERS;
+
+        private sealed interface ABNFCharRange {
+            static ABNFCharRange of(char character) {
+                return range(character, character);
+            }
+
+            static ABNFCharRange of(int character) {
+                return of((char)character);
+            }
+
+            static ABNFCharRange of(char ...characters) {
+                var ranges = new ABNFCharRange[characters.length];
+                for (int i = 0; i < characters.length; i++) {
+                    ranges[i] = ABNFCharRange.of(characters[i]);
+                }
+                return new ABNFCharCompositeRange(ranges);
+            }
+
+            static ABNFCharRange range(int start, int endInclusive) {
+                if(endInclusive < start) {
+                    // This is an empty range
+                    return new ABNFCharCompositeRange();
+                }
+                return new ABNFCharSingleRange(start, endInclusive);
+            }
+
+            boolean isEmpty();
+
+            String toRegexCharacterClass();
+        }
+
+        private record ABNFCharCompositeRange(ABNFCharRange ...ranges) implements ABNFCharRange {
+
+            @Override
+            public boolean isEmpty() {
+                return Arrays.stream(ranges).allMatch(ABNFCharRange::isEmpty);
+            }
+
+            @Override
+            public String toRegexCharacterClass() {
+                return Arrays.stream(ranges)
+                        .filter(Predicate.not(ABNFCharRange::isEmpty))
+                        .map(ABNFCharRange::toRegexCharacterClass)
+                        .collect(Collectors.joining());
+            }
+
+            @Override
+            public String toString() {
+                return "["+toRegexCharacterClass()+"]";
+            }
+        }
+
+        private record ABNFCharSingleRange(int start, int endInclusive) implements ABNFCharRange {
+
+            @Override
+            public boolean isEmpty() {
+                return endInclusive < start;
+            }
+
+            private static String encodeCharacter(int character) {
+                var hexString = Integer.toHexString(character);
+                return switch (hexString.length()) {
+                    case 1 -> "\\x0" + hexString;
+                    case 2 -> "\\x" + hexString;
+                    case 3 -> "\\u0" + hexString;
+                    case 4 -> "\\u" + hexString;
+                    default -> "\\x{" + hexString + "}";
+                };
+            }
+
+            @Override
+            public String toRegexCharacterClass() {
+                if(start == endInclusive) {
+                    return encodeCharacter(start);
+                }
+                return encodeCharacter(start)+"-"+ encodeCharacter(endInclusive);
+            }
+
+            @Override
+            public String toString() {
+                if(start == endInclusive) {
+                    return encodeCharacter(start);
+                }
+                return "["+toRegexCharacterClass()+"]";
+            }
+        }
     }
 }

--- a/contentgrid-appserver-application-model/src/main/java/com/contentgrid/appserver/application/model/attributes/ContentAttribute.java
+++ b/contentgrid-appserver-application-model/src/main/java/com/contentgrid/appserver/application/model/attributes/ContentAttribute.java
@@ -180,8 +180,13 @@ public class ContentAttribute implements CompositeAttribute {
         private static final String PARAMETER = PARAMETER_NAME+ABNFCharRange.of('=')+PARAMETER_VALUE;
         private static final String PARAMETERS = "(?:"+OWS+ABNFCharRange.of(';')+OWS+"(?:"+PARAMETER+")?)*";
 
+        // Prevents a wildcard character being present as first character
+        private static final String NO_WILDCARD = "(?!"+ABNFCharRange.of('*')+")";
+
         //  https://www.rfc-editor.org/rfc/rfc9110.html#name-media-type
-        public static final String MEDIA_TYPE = TOKEN+"/"+TOKEN+PARAMETERS;
+        // But wildcards are not allowed, because this has to be a concrete media type (not an Accept header)
+        public static final String MEDIA_TYPE = NO_WILDCARD+TOKEN+ABNFCharRange.of('/')+NO_WILDCARD+TOKEN+PARAMETERS;
+
 
         private sealed interface ABNFCharRange {
             static ABNFCharRange of(char character) {

--- a/contentgrid-appserver-application-model/src/main/java/com/contentgrid/appserver/application/model/attributes/ContentAttribute.java
+++ b/contentgrid-appserver-application-model/src/main/java/com/contentgrid/appserver/application/model/attributes/ContentAttribute.java
@@ -15,12 +15,14 @@ import com.contentgrid.appserver.application.model.values.AttributeName;
 import com.contentgrid.appserver.application.model.values.ColumnName;
 import com.contentgrid.appserver.application.model.values.LinkName;
 import com.contentgrid.appserver.application.model.values.PathSegmentName;
+import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.Predicate;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.AccessLevel;
@@ -36,7 +38,8 @@ import lombok.experimental.Delegate;
 public class ContentAttribute implements CompositeAttribute {
 
     // package-private for testing
-    static final RegexPatternConstraint MIMETYPE_PATTERN_CONSTRAINT = Constraint.pattern(MediaTypeABNF.MEDIA_TYPE);
+    static final RegexPatternConstraint MIMETYPE_PATTERN_CONSTRAINT = Constraint.pattern(MediaTypeABNF.mediaType(true))
+            .withHtmlPattern(MediaTypeABNF.mediaType(false));
 
     @NonNull
     AttributeName name;
@@ -178,14 +181,35 @@ public class ContentAttribute implements CompositeAttribute {
         private static final String PARAMETER_NAME = TOKEN;
         private static final String PARAMETER_VALUE = "(?:"+TOKEN+"|"+QUOTED_STRING+")";
         private static final String PARAMETER = PARAMETER_NAME+ABNFCharRange.of('=')+PARAMETER_VALUE;
-        private static final String PARAMETERS = "(?:"+OWS+ABNFCharRange.of(';')+OWS+"(?:"+PARAMETER+")?)*";
-
         // Prevents a wildcard character being present as first character
         private static final String NO_WILDCARD = "(?!"+ABNFCharRange.of('*')+")";
 
+        private static String parameters(boolean restrictCharset) {
+            var anyParameter = PARAMETER;
+            if(restrictCharset) {
+                // Prevents unknown charsets being used in the charset= parameter
+                final String KNOWN_CHARSETS = Charset.availableCharsets().values().stream()
+                        .flatMap(charset -> Stream.concat(Stream.of(charset.name()), charset.aliases().stream()))
+                        .map(Pattern::quote)
+                        .collect(Collectors.joining("|"));
+
+                // A charset parameter: name is 'charset' (case-insensitive), value must be a known charset (case-insensitive, optionally quoted)
+                final String CHARSET_PARAMETER =
+                        "(?i:charset)=(?:(?i:" + KNOWN_CHARSETS + ")|" + DQUOTE + "(?i:" + KNOWN_CHARSETS + ")" + DQUOTE
+                                + ")";
+                // A non-charset parameter: any parameter where name is not 'charset' (case-insensitive)
+                final String NON_CHARSET_PARAMETER = "(?!(?i:charset)=)" + PARAMETER;
+                anyParameter = "(?:"+CHARSET_PARAMETER+"|"+NON_CHARSET_PARAMETER+")";
+            }
+
+            return "(?:"+OWS+ABNFCharRange.of(';')+OWS+"(?:"+anyParameter+")?)*";
+        }
+
         //  https://www.rfc-editor.org/rfc/rfc9110.html#name-media-type
         // But wildcards are not allowed, because this has to be a concrete media type (not an Accept header)
-        public static final String MEDIA_TYPE = NO_WILDCARD+TOKEN+ABNFCharRange.of('/')+NO_WILDCARD+TOKEN+PARAMETERS;
+        public static String mediaType(boolean restrictCharset) {
+            return NO_WILDCARD+TOKEN+ABNFCharRange.of('/')+NO_WILDCARD+TOKEN+parameters(restrictCharset);
+        }
 
 
         private sealed interface ABNFCharRange {

--- a/contentgrid-appserver-application-model/src/test/java/com/contentgrid/appserver/application/model/attributes/ContentAttributeTest.java
+++ b/contentgrid-appserver-application-model/src/test/java/com/contentgrid/appserver/application/model/attributes/ContentAttributeTest.java
@@ -1,6 +1,7 @@
 package com.contentgrid.appserver.application.model.attributes;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 import com.contentgrid.appserver.application.model.i18n.UserLocales;
 import com.contentgrid.appserver.application.model.values.AttributeName;
@@ -18,6 +19,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.http.MediaType;
 
 class ContentAttributeTest {
 
@@ -101,6 +103,9 @@ class ContentAttributeTest {
         @MethodSource
         void validMimetypes(String mediaType) {
             assertThat(ContentAttribute.MIMETYPE_PATTERN_CONSTRAINT.getPattern().matcher(mediaType).matches()).isTrue();
+            assertThatCode(() -> {
+                MediaType.parseMediaType(mediaType);
+            }).doesNotThrowAnyException();
         }
 
         @ParameterizedTest

--- a/contentgrid-appserver-application-model/src/test/java/com/contentgrid/appserver/application/model/attributes/ContentAttributeTest.java
+++ b/contentgrid-appserver-application-model/src/test/java/com/contentgrid/appserver/application/model/attributes/ContentAttributeTest.java
@@ -7,10 +7,17 @@ import com.contentgrid.appserver.application.model.values.AttributeName;
 import com.contentgrid.appserver.application.model.values.ColumnName;
 import com.contentgrid.appserver.application.model.values.LinkName;
 import com.contentgrid.appserver.application.model.values.PathSegmentName;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
 import java.util.Collection;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class ContentAttributeTest {
 
@@ -66,6 +73,42 @@ class ContentAttributeTest {
 
         assertThat(attr.getFilename().getTranslations(UNSUPPORTED_USERLOCALES).getName()).isEqualTo("filename");
         assertThat(attr.getLength().getTranslations(UNSUPPORTED_USERLOCALES).getName()).isEqualTo("length");
+    }
+
+    @Nested
+    class MimetypeConstraintTest {
+
+        public static Stream<String> readLines(String file) throws IOException {
+            var resourceAsStream = Objects.requireNonNull(MimetypeConstraintTest.class.getResourceAsStream(file));
+            try(var reader = new BufferedReader(new InputStreamReader(
+                    resourceAsStream))) {
+                return reader.lines()
+                        .filter(line -> !line.isEmpty() && !line.startsWith("#"))
+                        .toList() // Need to materialize the stream before the try-with-resources closes the inputstream
+                        .stream();
+            }
+        }
+
+        public static Stream<String> validMimetypes() throws IOException {
+            return readLines("valid-mimetypes.txt");
+        }
+
+        public static Stream<String> invalidMimetypes() throws IOException {
+            return readLines("invalid-mimetypes.txt");
+        }
+
+        @ParameterizedTest
+        @MethodSource
+        void validMimetypes(String mediaType) {
+            assertThat(ContentAttribute.MIMETYPE_PATTERN_CONSTRAINT.getPattern().matcher(mediaType).matches()).isTrue();
+        }
+
+        @ParameterizedTest
+        @MethodSource
+        void invalidMimetypes(String mediaType) {
+            assertThat(ContentAttribute.MIMETYPE_PATTERN_CONSTRAINT.getPattern().matcher(mediaType).matches()).isFalse();
+        }
+
     }
 
 }

--- a/contentgrid-appserver-application-model/src/test/java/com/contentgrid/appserver/application/model/attributes/ContentAttributeTest.java
+++ b/contentgrid-appserver-application-model/src/test/java/com/contentgrid/appserver/application/model/attributes/ContentAttributeTest.java
@@ -14,6 +14,7 @@ import java.io.InputStreamReader;
 import java.util.Collection;
 import java.util.Locale;
 import java.util.Objects;
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -102,7 +103,11 @@ class ContentAttributeTest {
         @ParameterizedTest
         @MethodSource
         void validMimetypes(String mediaType) {
+            // server-side validation pattern matches
             assertThat(ContentAttribute.MIMETYPE_PATTERN_CONSTRAINT.getPattern().matcher(mediaType).matches()).isTrue();
+            // client-side validation pattern matches
+            assertThat(Pattern.matches(ContentAttribute.MIMETYPE_PATTERN_CONSTRAINT.getHtmlPattern(), mediaType)).isTrue();
+            // media type parsing is also valid
             assertThatCode(() -> {
                 MediaType.parseMediaType(mediaType);
             }).doesNotThrowAnyException();

--- a/contentgrid-appserver-application-model/src/test/resources/com/contentgrid/appserver/application/model/attributes/invalid-mimetypes.txt
+++ b/contentgrid-appserver-application-model/src/test/resources/com/contentgrid/appserver/application/model/attributes/invalid-mimetypes.txt
@@ -1,0 +1,105 @@
+# Invalid media types per RFC 9110 ABNF
+
+# --- Missing type or subtype ---
+text/
+/plain
+/
+//
+
+# --- Missing slash separator entirely ---
+textplain
+application
+json
+
+# --- Empty string (TOKEN requires 1+ chars) ---
+
+
+# --- Multiple slashes ---
+text/plain/extra
+application//json
+text//
+
+# --- Whitespace in type or subtype (SP/HTAB are not tchar) ---
+te xt/plain
+text/pla in
+te	xt/plain
+text/pla	in
+
+# --- Leading or trailing whitespace (not consumed by OWS since OWS only appears around ";") ---
+ text/plain
+	text/plain
+
+# --- Whitespace within parameter value (unquoted) ---
+text/plain; charset=utf 8
+text/plain; charset=utf	8
+text/plain; boundary=--my boundary
+
+# --- Space around "=" in parameter (no OWS defined around "=") ---
+text/plain; charset =utf-8
+text/plain; charset= utf-8
+text/plain; charset = utf-8
+text/plain; charset	=utf-8
+text/plain; charset=	utf-8
+
+# --- Parameter without value ---
+text/plain; charset
+text/plain; charset;
+text/plain; charset=
+text/plain; a=1; charset; b=2
+
+# --- Parameter without name ---
+text/plain; =utf-8
+text/plain; =
+text/plain; ="utf-8"
+
+# --- Unclosed quoted string ---
+text/plain; charset="utf-8
+text/plain; charset="
+text/plain; foo="unterminated
+
+# --- Characters that are not tchar in type or subtype ---
+# tchar = !#$%&*+-.^_`|~ / DIGIT / ALPHA — everything else is invalid
+text@domain/plain
+text/plain?q=1
+[text]/plain
+text/[plain]
+text/plain(comment)
+(text)/plain
+text/plain{v2}
+{text}/plain
+text/plain<v2>
+<text>/plain
+text/plain>nope
+text/pl,ain
+text,type/plain
+text/plain\extra
+text\\plain/something
+
+# --- Slash in parameter name or value (not a tchar) ---
+text/plain; foo/bar=baz
+text/plain; charset=utf/8
+
+# --- At-sign, colon, comma etc. in token positions ---
+text/plain; foo@bar=baz
+text/plain; fo:o=bar
+text/plain; foo=bar@baz
+text/plain; foo=bar:baz
+
+# --- Unicode / non-ASCII in type or subtype (outside obs-text range, and obs-text not allowed in tokens) ---
+tëxt/plain
+text/plàin
+tèxt/hïml
+application/ünknown
+
+# --- Double semicolons with no content when parameter IS required ---
+# (note: ; with no parameter is valid, but ; with just spaces and then another ; and then nothing is also valid;
+#  this entry tests something that does NOT fit the regex regardless)
+text/plain; charset="foo"extra
+text/plain; charset="foo" extra
+
+# --- Content after closing quote that isn't a semicolon ---
+text/plain; foo="bar"baz
+text/plain; foo="bar" baz
+
+# --- Semicolon as the entire value ---
+text/plain; ;=value

--- a/contentgrid-appserver-application-model/src/test/resources/com/contentgrid/appserver/application/model/attributes/invalid-mimetypes.txt
+++ b/contentgrid-appserver-application-model/src/test/resources/com/contentgrid/appserver/application/model/attributes/invalid-mimetypes.txt
@@ -11,8 +11,6 @@ textplain
 application
 json
 
-# --- Empty string (TOKEN requires 1+ chars) ---
-
 
 # --- Multiple slashes ---
 text/plain/extra
@@ -90,12 +88,6 @@ tëxt/plain
 text/plàin
 tèxt/hïml
 application/ünknown
-
-# --- Double semicolons with no content when parameter IS required ---
-# (note: ; with no parameter is valid, but ; with just spaces and then another ; and then nothing is also valid;
-#  this entry tests something that does NOT fit the regex regardless)
-text/plain; charset="foo"extra
-text/plain; charset="foo" extra
 
 # --- Content after closing quote that isn't a semicolon ---
 text/plain; foo="bar"baz

--- a/contentgrid-appserver-application-model/src/test/resources/com/contentgrid/appserver/application/model/attributes/invalid-mimetypes.txt
+++ b/contentgrid-appserver-application-model/src/test/resources/com/contentgrid/appserver/application/model/attributes/invalid-mimetypes.txt
@@ -55,6 +55,11 @@ text/plain; charset="utf-8
 text/plain; charset="
 text/plain; foo="unterminated
 
+# --- Invalid charset ---
+text/plain; charset=""
+text/plain; charset="abc def"
+text/plain; charset=abc
+
 # --- Characters that are not tchar in type or subtype ---
 # tchar = !#$%&*+-.^_`|~ / DIGIT / ALPHA — everything else is invalid
 text@domain/plain

--- a/contentgrid-appserver-application-model/src/test/resources/com/contentgrid/appserver/application/model/attributes/invalid-mimetypes.txt
+++ b/contentgrid-appserver-application-model/src/test/resources/com/contentgrid/appserver/application/model/attributes/invalid-mimetypes.txt
@@ -95,3 +95,9 @@ text/plain; foo="bar" baz
 
 # --- Semicolon as the entire value ---
 text/plain; ;=value
+
+# --- Wildcard combinations (asterisk is tchar, but a defined mediatype can't have a wildcard) ---
+*/*
+*/plain
+text/*
+**/**

--- a/contentgrid-appserver-application-model/src/test/resources/com/contentgrid/appserver/application/model/attributes/valid-mimetypes.txt
+++ b/contentgrid-appserver-application-model/src/test/resources/com/contentgrid/appserver/application/model/attributes/valid-mimetypes.txt
@@ -90,7 +90,6 @@ text/plain; foo="\	"
 text/plain; foo="a\"b\"c"
 
 # --- Quoted-string: empty value ---
-text/plain; charset=""
 text/plain; foo=""
 
 # --- Semicolons with no parameter (PARAMETER is optional in PARAMETERS) ---

--- a/contentgrid-appserver-application-model/src/test/resources/com/contentgrid/appserver/application/model/attributes/valid-mimetypes.txt
+++ b/contentgrid-appserver-application-model/src/test/resources/com/contentgrid/appserver/application/model/attributes/valid-mimetypes.txt
@@ -30,16 +30,12 @@ t/1
 0/0
 
 # --- All special tchar characters used in type/subtype ---
-# tchar allows: ! # $ % & * + - . ^ _ ` | ~
+# tchar allows: ! # $ % & * + - . ^ _ ` | ~, but using the wildcard (*) is not allowed
 !/!
 #/#
 $/b
 %/b
 &/b
-*/plain
-a/*
-*/*
-text/*
 +/+
 -/-
 ./b
@@ -105,11 +101,6 @@ text/plain; charset=utf-8;
 # --- Parameter value using all tchar in token ---
 text/plain; boundary=!#$%&*+-.^_`|~azAZ09
 
-# --- Wildcard combinations (asterisk is tchar) ---
-*/*
-*/plain
-text/*
-**/**
 
 # --- x- prefix types ---
 x-custom/x-type

--- a/contentgrid-appserver-application-model/src/test/resources/com/contentgrid/appserver/application/model/attributes/valid-mimetypes.txt
+++ b/contentgrid-appserver-application-model/src/test/resources/com/contentgrid/appserver/application/model/attributes/valid-mimetypes.txt
@@ -99,8 +99,6 @@ text/plain; foo=""
 
 # --- Semicolons with no parameter (PARAMETER is optional in PARAMETERS) ---
 text/plain;
-text/plain;
-text/plain;
 text/plain; ; charset=utf-8
 text/plain; charset=utf-8;
 

--- a/contentgrid-appserver-application-model/src/test/resources/com/contentgrid/appserver/application/model/attributes/valid-mimetypes.txt
+++ b/contentgrid-appserver-application-model/src/test/resources/com/contentgrid/appserver/application/model/attributes/valid-mimetypes.txt
@@ -1,0 +1,124 @@
+# Valid media types per RFC 9110 ABNF
+# type "/" subtype *( OWS ";" OWS [ parameter ] )
+# where parameter = token "=" (token | quoted-string)
+# and token = 1*tchar, tchar = !#$%&*+-.^_`|~ / DIGIT / ALPHA
+
+# --- Everyday types ---
+text/plain
+image/jpeg
+application/json
+video/mp4
+audio/mpeg
+font/woff2
+model/gltf+json
+
+# --- Uppercase and mixed-case (ALPHA includes A-Z) ---
+TEXT/PLAIN
+IMAGE/JPEG
+APPLICATION/JSON
+Text/Plain
+tExT/hTmL
+
+# --- Single-character type or subtype ---
+a/b
+x/y
+t/1
+
+# --- All-digit token (DIGIT is valid tchar) ---
+1/2
+123/456
+0/0
+
+# --- All special tchar characters used in type/subtype ---
+# tchar allows: ! # $ % & * + - . ^ _ ` | ~
+!/!
+#/#
+$/b
+%/b
+&/b
+*/plain
+a/*
+*/*
+text/*
++/+
+-/-
+./b
+^/b
+_/b
+`/b
+|/b
+~/b
+
+# --- Dotted and hyphenated subtypes ---
+application/vnd.ms-excel
+application/vnd.api+json
+application/ld+json
+application/x-www-form-urlencoded
+application/octet-stream
+application/x-tar
+image/svg+xml
+application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
+video/x-msvideo
+application/x-7z-compressed
+application/vnd.oasis.opendocument.text
+application/x.custom-type
+
+# --- Parameters: unquoted token values ---
+text/plain; charset=utf-8
+text/html; charset=us-ascii
+multipart/form-data; boundary=----WebKitFormBoundary
+text/plain; charset=utf-8; format=flowed
+application/json; charset=utf-8
+text/plain;charset=utf-8
+text/plain;a=1;b=2;c=3
+
+# --- Parameters: OWS (optional whitespace) around semicolon ---
+text/plain ; charset=utf-8
+text/plain	;charset=utf-8
+text/plain ;	charset=utf-8
+text/plain	;	charset=utf-8
+text/plain; charset=utf-8 ; format=flowed
+
+# --- Parameters: quoted-string values ---
+text/plain; charset="utf-8"
+text/plain; charset="us-ascii"
+text/plain; foo="bar baz"
+text/plain; foo="bar	baz"
+text/plain; foo="hello world"
+
+# --- Quoted-string: escaped characters (quoted-pair = "\" ( HTAB / SP / VCHAR / obs-text )) ---
+text/plain; foo="bar\"baz"
+text/plain; foo="\\"
+text/plain; foo="\ "
+text/plain; foo="\	"
+text/plain; foo="a\"b\"c"
+
+# --- Quoted-string: empty value ---
+text/plain; charset=""
+text/plain; foo=""
+
+# --- Semicolons with no parameter (PARAMETER is optional in PARAMETERS) ---
+text/plain;
+text/plain;
+text/plain;
+text/plain; ; charset=utf-8
+text/plain; charset=utf-8;
+
+# --- Parameter value using all tchar in token ---
+text/plain; boundary=!#$%&*+-.^_`|~azAZ09
+
+# --- Wildcard combinations (asterisk is tchar) ---
+*/*
+*/plain
+text/*
+**/**
+
+# --- x- prefix types ---
+x-custom/x-type
+x-/x-
+
+# --- Vendor types ---
+application/vnd.github+json
+application/vnd.collection+json
+application/vnd.hal+json
+application/problem+json

--- a/contentgrid-appserver-application-model/src/testFixtures/java/com/contentgrid/appserver/application/model/fixtures/ModelTestFixtures.java
+++ b/contentgrid-appserver-application-model/src/testFixtures/java/com/contentgrid/appserver/application/model/fixtures/ModelTestFixtures.java
@@ -244,6 +244,7 @@ public class ModelTestFixtures {
             .type(Type.TEXT)
             .constraint(Constraint.required())
             .constraint(Constraint.unique())
+            .constraint(Constraint.pattern("[0-9]+"))
             .build();
 
     public static final SimpleAttribute INVOICE_AMOUNT = SimpleAttribute.builder()

--- a/contentgrid-appserver-domain/src/main/java/com/contentgrid/appserver/domain/DatamodelApiImpl.java
+++ b/contentgrid-appserver-domain/src/main/java/com/contentgrid/appserver/domain/DatamodelApiImpl.java
@@ -27,6 +27,7 @@ import com.contentgrid.appserver.domain.data.mapper.RequestInputDataToDataEntryM
 import com.contentgrid.appserver.domain.data.validation.AllowedValuesConstraintValidator;
 import com.contentgrid.appserver.domain.data.validation.AttributeValidationDataMapper;
 import com.contentgrid.appserver.domain.data.validation.ContentAttributeModificationValidator;
+import com.contentgrid.appserver.domain.data.validation.RegexPatternConstraintValidator;
 import com.contentgrid.appserver.domain.data.validation.RelationRequiredValidationDataMapper;
 import com.contentgrid.appserver.domain.data.validation.RequiredAttributeConstraintValidator;
 import com.contentgrid.appserver.domain.data.validation.ValidationExceptionCollector;
@@ -102,7 +103,8 @@ public class DatamodelApiImpl implements DatamodelApi {
                         AttributeAndRelationMapper.from(
                                 new AttributeValidationDataMapper(
                                         new RequiredAttributeConstraintValidator(),
-                                        new AllowedValuesConstraintValidator()
+                                        new AllowedValuesConstraintValidator(),
+                                        new RegexPatternConstraintValidator()
                                 ),
                                 new RelationRequiredValidationDataMapper()
                         )

--- a/contentgrid-appserver-domain/src/main/java/com/contentgrid/appserver/domain/data/validation/RegexPatternConstraintValidator.java
+++ b/contentgrid-appserver-domain/src/main/java/com/contentgrid/appserver/domain/data/validation/RegexPatternConstraintValidator.java
@@ -1,0 +1,43 @@
+package com.contentgrid.appserver.domain.data.validation;
+
+import com.contentgrid.appserver.application.model.Constraint.RegexPatternConstraint;
+import com.contentgrid.appserver.domain.data.DataEntry;
+import com.contentgrid.appserver.domain.data.DataEntry.MissingDataEntry;
+import com.contentgrid.appserver.domain.data.DataEntry.NullDataEntry;
+import com.contentgrid.appserver.domain.data.DataEntry.ScalarDataEntry;
+import com.contentgrid.appserver.domain.data.InvalidDataException;
+import com.contentgrid.appserver.domain.data.type.DataType;
+import com.contentgrid.appserver.domain.data.validation.AttributeValidationDataMapper.ConstraintValidator;
+import java.util.Objects;
+
+public class RegexPatternConstraintValidator implements ConstraintValidator<RegexPatternConstraint> {
+
+    @Override
+    public Class<RegexPatternConstraint> getConstraintType() {
+        return RegexPatternConstraint.class;
+    }
+
+    @Override
+    public void validate(RegexPatternConstraint constraint, DataEntry dataEntry) throws InvalidDataException {
+        if (dataEntry instanceof NullDataEntry || dataEntry instanceof MissingDataEntry) {
+            // Validator does not check empty or null values, they are allowed
+            return;
+        }
+        if (dataEntry instanceof ScalarDataEntry scalarDataEntry) {
+            var stringValue = Objects.toString(scalarDataEntry.getValue());
+            if(constraint.getPattern().matcher(stringValue).matches()) {
+                // This is a valid value, return without throwing
+                return;
+            }
+            throw new RegexPatternConstraintViolationInvalidDataException(stringValue, constraint.getPattern());
+
+        }
+        throw new IllegalArgumentException(
+                "%s does not support %s".formatted(
+                        RegexPatternConstraintValidator.class,
+                        DataType.of(dataEntry)
+                )
+        );
+
+    }
+}

--- a/contentgrid-appserver-domain/src/main/java/com/contentgrid/appserver/domain/data/validation/RegexPatternConstraintViolationInvalidDataException.java
+++ b/contentgrid-appserver-domain/src/main/java/com/contentgrid/appserver/domain/data/validation/RegexPatternConstraintViolationInvalidDataException.java
@@ -1,0 +1,22 @@
+package com.contentgrid.appserver.domain.data.validation;
+
+import com.contentgrid.appserver.domain.data.InvalidDataException;
+import java.util.regex.Pattern;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public class RegexPatternConstraintViolationInvalidDataException extends InvalidDataException {
+    @NonNull
+    private final String actualValue;
+
+    @NonNull
+    private final Pattern pattern;
+
+    @Override
+    public String getMessage() {
+        return "Value must match pattern '%s', but '%s' doesn't match".formatted(pattern.pattern(), actualValue);
+    }
+}

--- a/contentgrid-appserver-domain/src/test/java/com/contentgrid/appserver/domain/DatamodelApiImplTest.java
+++ b/contentgrid-appserver-domain/src/test/java/com/contentgrid/appserver/domain/DatamodelApiImplTest.java
@@ -188,7 +188,7 @@ class DatamodelApiImplTest {
             Mockito.when(queryEngine.create(Mockito.any(), createDataCaptor.capture(), Mockito.any(), Mockito.any()))
                     .thenReturn(EntityData.builder().name(INVOICE.getName()).id(entityId).build());
             var result = datamodelApi.create(APPLICATION, INVOICE.getName(), MapRequestInputData.fromMap(Map.of(
-                            "number", "invoice-1",
+                            "number", "1",
                             "amount", 1.50,
                             "received", LocalDate.now(clock),
                             "pay_before", LocalDate.now(clock).plusDays(30),
@@ -206,7 +206,7 @@ class DatamodelApiImplTest {
                 assertThat(createData.getEntityName()).isEqualTo(INVOICE.getName());
                 assertThat(createData.getAttributes())
                         .containsExactlyInAnyOrder(
-                        new SimpleAttributeData<>(INVOICE_NUMBER.getName(), "invoice-1"),
+                        new SimpleAttributeData<>(INVOICE_NUMBER.getName(), "1"),
                         new SimpleAttributeData<>(INVOICE_AMOUNT.getName(), BigDecimal.valueOf(1.50)),
                         new SimpleAttributeData<>(INVOICE_RECEIVED.getName(), LocalDate.now(clock)),
                         new SimpleAttributeData<>(INVOICE_PAY_BEFORE.getName(), LocalDate.now(clock).plusDays(30)),
@@ -292,7 +292,7 @@ class DatamodelApiImplTest {
 
             assertThatThrownBy(() -> {
                 datamodelApi.create(APPLICATION, INVOICE.getName(), MapRequestInputData.fromMap(Map.of(
-                        "number", "invoice-1",
+                        "number", "1",
                         "amount", 1.50,
                         "received", LocalDate.now(clock),
                         "pay_before", LocalDate.now(clock).plusDays(30),
@@ -325,7 +325,7 @@ class DatamodelApiImplTest {
                     .thenReturn(EntityData.builder().name(INVOICE.getName()).id(entityId).build());
 
             var result = datamodelApi.create(APPLICATION, INVOICE.getName(), MapRequestInputData.fromMap(Map.of(
-                            "number", "invoice-1",
+                            "number", "1",
                             "amount", 1.50,
                             "confidentiality", "public",
                             "customer", new RelationDataEntry(PERSON.getName(), personId),
@@ -342,7 +342,7 @@ class DatamodelApiImplTest {
                 assertThat(createData.getEntityName()).isEqualTo(INVOICE.getName());
                 assertThat(createData.getAttributes())
                         .containsExactlyInAnyOrder(
-                        new SimpleAttributeData<>(INVOICE_NUMBER.getName(), "invoice-1"),
+                        new SimpleAttributeData<>(INVOICE_NUMBER.getName(), "1"),
                         new SimpleAttributeData<>(INVOICE_AMOUNT.getName(), BigDecimal.valueOf(1.50)),
                         new SimpleAttributeData<>(INVOICE_CONFIDENTIALITY.getName(), "public"),
                         new SimpleAttributeData<>(INVOICE_RECEIVED.getName(), null),
@@ -446,7 +446,7 @@ class DatamodelApiImplTest {
                     .thenReturn(EntityData.builder().name(INVOICE.getName()).id(entityId).build());
 
             var result = datamodelApi.create(APPLICATION, INVOICE.getName(), MapRequestInputData.fromMap(Map.of(
-                    "number", "invoice-1",
+                    "number", "1",
                     "amount", 1.50,
                     "confidentiality", "public",
                     "customer", new RelationDataEntry(PERSON.getName(), personId)
@@ -491,7 +491,7 @@ class DatamodelApiImplTest {
                     List.of());
 
             var result = datamodelApi.update(APPLICATION, existing, MapRequestInputData.fromMap(Map.of(
-                    "number", "invoice-1",
+                    "number", "1",
                     "amount", 1.50,
                     "confidentiality", "public",
                     "customer", new RelationDataEntry(PERSON.getName(), personId)
@@ -534,7 +534,7 @@ class DatamodelApiImplTest {
                     List.of());
 
             var result = datamodelApi.updatePartial(APPLICATION, existing, MapRequestInputData.fromMap(Map.of(
-                    "number", "invoice-1",
+                    "number", "1",
                     "amount", 1.50,
                     "confidentiality", "public",
                     "customer", new RelationDataEntry(PERSON.getName(), personId)
@@ -581,7 +581,7 @@ class DatamodelApiImplTest {
 
             assertThatThrownBy(() -> {
                  datamodelApi.create(APPLICATION, INVOICE.getName(), MapRequestInputData.fromMap(Map.of(
-                        "number", "invoice-1",
+                        "number", "1",
                         "amount", 1.50,
                         "confidentiality", "public",
                         "customer", customer,
@@ -628,7 +628,7 @@ class DatamodelApiImplTest {
             Mockito.when(contentStore.writeContent(Mockito.any())).thenAnswer(contentAccessorFor(fileId));
 
             var result = datamodelApi.create(APPLICATION, INVOICE.getName(), MapRequestInputData.fromMap(Map.of(
-                    "number", "invoice-1",
+                    "number", "1",
                     "amount", 1.50,
                     "confidentiality", "public",
                     "customer", new RelationDataEntry(PERSON.getName(), personId),
@@ -641,7 +641,7 @@ class DatamodelApiImplTest {
                 assertThat(createData.getEntityName()).isEqualTo(INVOICE.getName());
                 assertThat(createData.getAttributes())
                         .containsExactlyInAnyOrder(
-                                new SimpleAttributeData<>(INVOICE_NUMBER.getName(), "invoice-1"),
+                                new SimpleAttributeData<>(INVOICE_NUMBER.getName(), "1"),
                                 new SimpleAttributeData<>(INVOICE_AMOUNT.getName(), BigDecimal.valueOf(1.50)),
                                 new SimpleAttributeData<>(INVOICE_RECEIVED.getName(), null),
                                 new SimpleAttributeData<>(INVOICE_PAY_BEFORE.getName(), null),
@@ -670,7 +670,7 @@ class DatamodelApiImplTest {
         void contentAttributes_fails() {
             var personId = EntityId.of(UUID.randomUUID());
             assertThatThrownBy(() -> datamodelApi.create(APPLICATION, INVOICE.getName(), MapRequestInputData.fromMap(Map.of(
-                    "number", "invoice-1",
+                    "number", "1",
                     "amount", 1.50,
                     "confidentiality", "public",
                     "customer", new RelationDataEntry(PERSON.getName(), personId),
@@ -719,7 +719,7 @@ class DatamodelApiImplTest {
                     .thenReturn(new UpdateResult(entity, entity));
             datamodelApi.update(APPLICATION, EntityRequest.forEntity(INVOICE.getName(), entityId),
                     MapRequestInputData.fromMap(Map.of(
-                            "number", "invoice-1",
+                            "number", "1",
                             "amount", 1.50,
                             "received", LocalDate.now(clock),
                             "confidentiality", "public",
@@ -732,7 +732,7 @@ class DatamodelApiImplTest {
             assertThat(createDataCaptor.getValue().getId()).isEqualTo(entityId);
             assertThat(createDataCaptor.getValue().getName()).isEqualTo(INVOICE.getName());
             assertThat(createDataCaptor.getValue().getAttributes()).containsExactlyInAnyOrder(
-                    new SimpleAttributeData<>(INVOICE_NUMBER.getName(), "invoice-1"),
+                    new SimpleAttributeData<>(INVOICE_NUMBER.getName(), "1"),
                     new SimpleAttributeData<>(INVOICE_AMOUNT.getName(), BigDecimal.valueOf(1.50)),
                     new SimpleAttributeData<>(INVOICE_RECEIVED.getName(), LocalDate.now(clock)),
                     new SimpleAttributeData<>(INVOICE_CONFIDENTIALITY.getName(), "public"),
@@ -793,7 +793,7 @@ class DatamodelApiImplTest {
                     .thenReturn(new UpdateResult(entity, entity));
             datamodelApi.update(APPLICATION, EntityRequest.forEntity(INVOICE.getName(), entityId),
                     MapRequestInputData.fromMap(Map.of(
-                            "number", "invoice-1",
+                            "number", "1",
                             "amount", 1.50,
                             "confidentiality", "public",
                             "content", Map.of(
@@ -809,7 +809,7 @@ class DatamodelApiImplTest {
             assertThat(createDataCaptor.getValue().getId()).isEqualTo(entityId);
             assertThat(createDataCaptor.getValue().getName()).isEqualTo(INVOICE.getName());
             assertThat(createDataCaptor.getValue().getAttributes()).containsExactlyInAnyOrder(
-                    new SimpleAttributeData<>(INVOICE_NUMBER.getName(), "invoice-1"),
+                    new SimpleAttributeData<>(INVOICE_NUMBER.getName(), "1"),
                     new SimpleAttributeData<>(INVOICE_AMOUNT.getName(), BigDecimal.valueOf(1.50)),
                     new SimpleAttributeData<>(INVOICE_CONFIDENTIALITY.getName(), "public"),
                     // Missing values are set to null
@@ -836,7 +836,7 @@ class DatamodelApiImplTest {
             assertThatThrownBy(() -> {
                 datamodelApi.update(APPLICATION, EntityRequest.forEntity(INVOICE.getName(), entityId),
                         MapRequestInputData.fromMap(Map.of(
-                                "number", "invoice-1",
+                                "number", "1",
                                 "amount", 1.50,
                                 "content", Map.of(
                                         "filename", "file-123.pdf",
@@ -868,7 +868,7 @@ class DatamodelApiImplTest {
             assertThatThrownBy(() -> {
                 datamodelApi.update(APPLICATION, EntityRequest.forEntity(INVOICE.getName(), entityId),
                         MapRequestInputData.fromMap(Map.of(
-                                "number", "invoice-1",
+                                "number", "1",
                                 "amount", 1.50,
                                 "content", Map.of(
                                         "filename", "file-123.pdf",
@@ -900,7 +900,7 @@ class DatamodelApiImplTest {
                     .thenReturn(new UpdateResult(entity, entity));
             datamodelApi.update(APPLICATION, EntityRequest.forEntity(INVOICE.getName(), entityId),
                     MapRequestInputData.fromMap(Map.of(
-                            "number", "invoice-1",
+                            "number", "1",
                             "amount", 1.50,
                             "confidentiality", "public",
                             "content", Map.of(
@@ -914,7 +914,7 @@ class DatamodelApiImplTest {
             assertThat(createDataCaptor.getValue().getId()).isEqualTo(entityId);
             assertThat(createDataCaptor.getValue().getName()).isEqualTo(INVOICE.getName());
             assertThat(createDataCaptor.getValue().getAttributes()).containsExactlyInAnyOrder(
-                    new SimpleAttributeData<>(INVOICE_NUMBER.getName(), "invoice-1"),
+                    new SimpleAttributeData<>(INVOICE_NUMBER.getName(), "1"),
                     new SimpleAttributeData<>(INVOICE_AMOUNT.getName(), BigDecimal.valueOf(1.50)),
                     new SimpleAttributeData<>(INVOICE_CONFIDENTIALITY.getName(), "public"),
                     // Missing values are set to null
@@ -952,7 +952,7 @@ class DatamodelApiImplTest {
 
             datamodelApi.update(APPLICATION, EntityRequest.forEntity(INVOICE.getName(), entityId),
                     MapRequestInputData.fromMap(Map.of(
-                            "number", "invoice-1",
+                            "number", "1",
                             "amount", 1.50,
                             "confidentiality", "public",
                             "content", new FileDataEntry("my-file.pdf", "application/pdf", inputStreamWithSize(50))
@@ -963,7 +963,7 @@ class DatamodelApiImplTest {
             assertThat(createDataCaptor.getValue().getId()).isEqualTo(entityId);
             assertThat(createDataCaptor.getValue().getName()).isEqualTo(INVOICE.getName());
             assertThat(createDataCaptor.getValue().getAttributes()).containsExactlyInAnyOrder(
-                    new SimpleAttributeData<>(INVOICE_NUMBER.getName(), "invoice-1"),
+                    new SimpleAttributeData<>(INVOICE_NUMBER.getName(), "1"),
                     new SimpleAttributeData<>(INVOICE_AMOUNT.getName(), BigDecimal.valueOf(1.50)),
                     new SimpleAttributeData<>(INVOICE_CONFIDENTIALITY.getName(), "public"),
                     // Missing values are set to null
@@ -1004,7 +1004,7 @@ class DatamodelApiImplTest {
                     .thenReturn(new UpdateResult(entity, entity));
             datamodelApi.updatePartial(APPLICATION, EntityRequest.forEntity(INVOICE.getName(), entityId),
                     MapRequestInputData.fromMap(Map.of(
-                            "number", "invoice-1",
+                            "number", "1",
                             "amount", MissingDataEntry.INSTANCE, // Required value is missing completely
                             "confidentiality", "public",
                             "received", LocalDate.now(clock),
@@ -1018,7 +1018,7 @@ class DatamodelApiImplTest {
             assertThat(createDataCaptor.getValue().getId()).isEqualTo(entityId);
             assertThat(createDataCaptor.getValue().getName()).isEqualTo(INVOICE.getName());
             assertThat(createDataCaptor.getValue().getAttributes()).containsExactlyInAnyOrder(
-                    new SimpleAttributeData<>(INVOICE_NUMBER.getName(), "invoice-1"),
+                    new SimpleAttributeData<>(INVOICE_NUMBER.getName(), "1"),
                     // amount is missing here, and thus not overwritten
                     new SimpleAttributeData<>(INVOICE_CONFIDENTIALITY.getName(), "public"),
                     new SimpleAttributeData<>(INVOICE_RECEIVED.getName(), LocalDate.now(clock)),
@@ -1151,7 +1151,7 @@ class DatamodelApiImplTest {
             assertThatThrownBy(() -> {
                 datamodelApi.update(APPLICATION, EntityRequest.forEntity(INVOICE.getName(), entityId),
                         MapRequestInputData.fromMap(Map.of(
-                        "number", "invoice-1",
+                        "number", "1",
                         "amount", 1.50,
                         "confidentiality", "public",
                         "content", Map.of(

--- a/contentgrid-appserver-integration-test/src/test/java/com/contentgrid/appserver/integration/test/problem/ContentGridProblemDetailsConfigurationIntegrationTest.java
+++ b/contentgrid-appserver-integration-test/src/test/java/com/contentgrid/appserver/integration/test/problem/ContentGridProblemDetailsConfigurationIntegrationTest.java
@@ -17,6 +17,7 @@ import com.contentgrid.appserver.integration.test.fixture.invoicing.InvoicingApi
 import com.contentgrid.appserver.integration.test.fixture.invoicing.InvoicingApiApplication;
 import com.contentgrid.appserver.rest.test.WithMockJwt;
 import java.util.List;
+import java.util.Random;
 import java.util.UUID;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeAll;
@@ -66,8 +67,12 @@ class ContentGridProblemDetailsConfigurationIntegrationTest {
         return invoicingApi.createCustomer(null, "vat-" + UUID.randomUUID()).getIdentity().getEntityId();
     }
 
+    private static String randomNumber() {
+        return String.valueOf(new Random().nextLong(0, Long.MAX_VALUE));
+    }
+
     private EntityId createInvoice() throws InvalidPropertyDataException {
-        return invoicingApi.createInvoice("invoice-" + UUID.randomUUID(), false, false, createCustomer(), null)
+        return invoicingApi.createInvoice(randomNumber(), false, false, createCustomer(), null)
                 .getIdentity().getEntityId();
     }
 
@@ -94,7 +99,7 @@ class ContentGridProblemDetailsConfigurationIntegrationTest {
             var customerId = invoicingApi.createCustomer(null, "vat-" + UUID.randomUUID()).getIdentity().getEntityId();
             CUSTOMER_ID_UPDATE = customerId.toString();
 
-            var invoiceId = invoicingApi.createInvoice("invoice-" + UUID.randomUUID(), false, false, customerId, null)
+            var invoiceId = invoicingApi.createInvoice(randomNumber(), false, false, customerId, null)
                     .getIdentity().getEntityId();
             INVOICE_ID_UPDATE = invoiceId.toString();
         }

--- a/contentgrid-appserver-json-schema/src/main/java/com/contentgrid/appserver/json/DefaultApplicationSchemaConverter.java
+++ b/contentgrid-appserver-json-schema/src/main/java/com/contentgrid/appserver/json/DefaultApplicationSchemaConverter.java
@@ -60,6 +60,7 @@ import com.contentgrid.appserver.json.model.Entity;
 import com.contentgrid.appserver.json.model.ManyToManyRelation;
 import com.contentgrid.appserver.json.model.OneToManyRelation;
 import com.contentgrid.appserver.json.model.OneToOneRelation;
+import com.contentgrid.appserver.json.model.PatternConstaint;
 import com.contentgrid.appserver.json.model.PropertyPathElement;
 import com.contentgrid.appserver.json.model.PropertyPathElement.PropertyPathElementType;
 import com.contentgrid.appserver.json.model.Relation;
@@ -70,11 +71,12 @@ import com.contentgrid.appserver.json.model.SimpleAttribute;
 import com.contentgrid.appserver.json.model.SortableField;
 import com.contentgrid.appserver.json.model.Translations;
 import com.contentgrid.appserver.json.model.Translations.EmptyTranslation;
+import com.contentgrid.appserver.json.model.Translations.MultipleTranslations;
+import com.contentgrid.appserver.json.model.Translations.SingleTranslation;
 import com.contentgrid.appserver.json.model.UniqueConstraint;
 import com.contentgrid.appserver.json.model.UserAttribute;
 import com.contentgrid.appserver.json.validation.ApplicationSchemaValidator;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import lombok.NonNull;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -303,6 +305,13 @@ public class DefaultApplicationSchemaConverter implements ApplicationSchemaConve
             case AllowedValuesConstraint avc -> Constraint.allowedValues(avc.getValues());
             case UniqueConstraint ignored -> Constraint.unique();
             case RequiredConstraint ignored -> Constraint.required();
+            case PatternConstaint patternConstaint -> {
+                var regexPatternConstraint = Constraint.pattern(patternConstaint.getRegex());
+                if (patternConstaint.getHtmlPattern() != null) {
+                    regexPatternConstraint = regexPatternConstraint.withHtmlPattern(patternConstaint.getHtmlPattern());
+                }
+                yield regexPatternConstraint;
+            }
         };
     }
 
@@ -320,7 +329,7 @@ public class DefaultApplicationSchemaConverter implements ApplicationSchemaConve
                 : fromJsonAttributeSearchFilter(jsonFilter, type, propertyPath, filterName);
     }
 
-    private com.contentgrid.appserver.application.model.searchfilters.FullTextSearchAttributeSearchFilter fromJsonFullTextSearchFilter(
+    private FullTextSearchAttributeSearchFilter fromJsonFullTextSearchFilter(
             SearchFilter jsonFilter, PropertyPath propertyPath, FilterName filterName) throws InvalidJsonException {
         Locale locale = Objects.requireNonNull(jsonFilter.getLocale(), "Full-text search filters require a locale to be set.");
 
@@ -556,15 +565,24 @@ public class DefaultApplicationSchemaConverter implements ApplicationSchemaConve
 
     private AttributeConstraint toJsonConstraint(Constraint constraint) {
         return switch (constraint) {
-            case com.contentgrid.appserver.application.model.Constraint.AllowedValuesConstraint allowedValuesConstraint -> {
+            case Constraint.AllowedValuesConstraint allowedValuesConstraint -> {
                 var avc = new AllowedValuesConstraint();
                 avc.setValues(allowedValuesConstraint.getValues());
                 yield avc;
             }
-            case com.contentgrid.appserver.application.model.Constraint.UniqueConstraint ignored ->
-                    new UniqueConstraint();
-            case com.contentgrid.appserver.application.model.Constraint.RequiredConstraint ignored ->
-                    new RequiredConstraint();
+            case Constraint.UniqueConstraint ignored -> new UniqueConstraint();
+            case Constraint.RequiredConstraint ignored -> new RequiredConstraint();
+            case Constraint.RegexPatternConstraint regexPatternConstraint -> {
+                var javaPattern = regexPatternConstraint.getPattern().pattern();
+                var htmlPattern = regexPatternConstraint.getHtmlPattern();
+                var pc = new PatternConstaint();
+                pc.setRegex(javaPattern);
+                // Canonical representation: htmlPattern is only present when it's not the same as the Java pattern
+                if (!Objects.equals(javaPattern, htmlPattern)) {
+                    pc.setHtmlPattern(htmlPattern);
+                }
+                yield  pc;
+            }
         };
     }
 
@@ -716,8 +734,8 @@ public class DefaultApplicationSchemaConverter implements ApplicationSchemaConve
             return EmptyTranslation.INSTANCE;
         }
         if(translations.size() == 1 && translations.containsKey(Locale.ROOT)) {
-            return new Translations.SingleTranslation(translations.get(Locale.ROOT));
+            return new SingleTranslation(translations.get(Locale.ROOT));
         }
-        return new Translations.MultipleTranslations(translations);
+        return new MultipleTranslations(translations);
     }
 }

--- a/contentgrid-appserver-json-schema/src/main/java/com/contentgrid/appserver/json/model/AttributeConstraint.java
+++ b/contentgrid-appserver-json-schema/src/main/java/com/contentgrid/appserver/json/model/AttributeConstraint.java
@@ -10,8 +10,10 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 )
 @JsonSubTypes({
         @JsonSubTypes.Type(value = AllowedValuesConstraint.class, name = "allowedValues"),
+        @JsonSubTypes.Type(value = PatternConstaint.class, name="pattern"),
         @JsonSubTypes.Type(value = UniqueConstraint.class, name = "unique"),
         @JsonSubTypes.Type(value = RequiredConstraint.class, name = "required")
 })
-public sealed interface AttributeConstraint permits AllowedValuesConstraint, UniqueConstraint, RequiredConstraint {
+public sealed interface AttributeConstraint permits AllowedValuesConstraint, PatternConstaint,
+        RequiredConstraint, UniqueConstraint {
 }

--- a/contentgrid-appserver-json-schema/src/main/java/com/contentgrid/appserver/json/model/PatternConstaint.java
+++ b/contentgrid-appserver-json-schema/src/main/java/com/contentgrid/appserver/json/model/PatternConstaint.java
@@ -1,0 +1,11 @@
+package com.contentgrid.appserver.json.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Data;
+
+@Data
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public final class PatternConstaint implements AttributeConstraint {
+    private String regex;
+    private String htmlPattern;
+}

--- a/contentgrid-appserver-json-schema/src/main/resources/schemas/application-schema.json
+++ b/contentgrid-appserver-json-schema/src/main/resources/schemas/application-schema.json
@@ -360,6 +360,29 @@
           "properties": {
             "type": {
               "type": "string",
+              "const": "pattern",
+              "description": "The type of constraint (e.g., unique, foreign key, allowed values)."
+            },
+            "regex": {
+              "type": "string",
+              "description": "The Java regular expression that will be used to validate the attribute value. The regular expression must match the entire value, and is implicitly anchored on both start and end."
+            },
+            "htmlPattern": {
+              "type": "string",
+              "description": "A html input pattern regular expression that will be sent to clients, and can be used for client-side validation of the attribute value. If omitted, defaults to the value of 'pattern'"
+            }
+          },
+          "required": [
+            "type",
+            "regex"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
               "const": "unique",
               "description": "The type of constraint (e.g., unique, foreign key, allowed values)."
             }

--- a/contentgrid-appserver-json-schema/src/test/resources/sample-application.json
+++ b/contentgrid-appserver-json-schema/src/test/resources/sample-application.json
@@ -151,7 +151,14 @@
           "description": "Employee's email address",
           "type": "simple",
           "columnName": "email",
-          "dataType": "text"
+          "dataType": "text",
+          "constraints": [
+            {
+              "type": "pattern",
+              "regex": ".+@.+\\..+",
+              "htmlPattern": ".+@.+"
+            }
+          ]
         },
         {
           "name": "hireDate",
@@ -188,7 +195,13 @@
               "description": "Employee's phone number",
               "type": "simple",
               "columnName": "phone",
-              "dataType": "text"
+              "dataType": "text",
+              "constraints": [
+                {
+                  "type": "pattern",
+                  "regex": "\\+[0-9]+"
+                }
+              ]
             },
             {
               "name": "address",

--- a/contentgrid-appserver-rest/src/main/java/com/contentgrid/appserver/rest/assembler/profile/hal/ProfileAttributeConstraintRepresentationModel.java
+++ b/contentgrid-appserver-rest/src/main/java/com/contentgrid/appserver/rest/assembler/profile/hal/ProfileAttributeConstraintRepresentationModel.java
@@ -3,6 +3,7 @@ package com.contentgrid.appserver.rest.assembler.profile.hal;
 import com.contentgrid.appserver.rest.assembler.profile.BlueprintLinkRelations;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
+import lombok.NonNull;
 import lombok.Value;
 import org.springframework.hateoas.server.core.Relation;
 
@@ -13,6 +14,10 @@ public sealed interface ProfileAttributeConstraintRepresentationModel {
 
     static AllowedValuesConstraintRepresentationModel allowedValues(List<String> values) {
         return new AllowedValuesConstraintRepresentationModel(values);
+    }
+
+    static PatternAttributeConstraintRepresentationModel pattern(@NonNull String pattern) {
+        return new PatternAttributeConstraintRepresentationModel(pattern);
     }
 
     static ProfileAttributeConstraintRepresentationModel required() {
@@ -48,6 +53,17 @@ public sealed interface ProfileAttributeConstraintRepresentationModel {
         @Override
         public String getType() {
             return "allowed-values";
+        }
+    }
+
+    @Value
+    @Relation(BlueprintLinkRelations.CONSTRAINT_STRING)
+    class PatternAttributeConstraintRepresentationModel implements ProfileAttributeConstraintRepresentationModel {
+        String pattern;
+
+        @Override
+        public String getType() {
+            return "pattern";
         }
     }
 

--- a/contentgrid-appserver-rest/src/main/java/com/contentgrid/appserver/rest/assembler/profile/hal/ProfileAttributeRepresentationModelAssembler.java
+++ b/contentgrid-appserver-rest/src/main/java/com/contentgrid/appserver/rest/assembler/profile/hal/ProfileAttributeRepresentationModelAssembler.java
@@ -2,6 +2,7 @@ package com.contentgrid.appserver.rest.assembler.profile.hal;
 
 import com.contentgrid.appserver.application.model.Constraint;
 import com.contentgrid.appserver.application.model.Constraint.AllowedValuesConstraint;
+import com.contentgrid.appserver.application.model.Constraint.RegexPatternConstraint;
 import com.contentgrid.appserver.application.model.Constraint.RequiredConstraint;
 import com.contentgrid.appserver.application.model.Constraint.UniqueConstraint;
 import com.contentgrid.appserver.application.model.Entity;
@@ -15,7 +16,6 @@ import com.contentgrid.appserver.application.model.attributes.flags.CreatedDateF
 import com.contentgrid.appserver.application.model.attributes.flags.CreatorFlag;
 import com.contentgrid.appserver.application.model.attributes.flags.ModifiedDateFlag;
 import com.contentgrid.appserver.application.model.attributes.flags.ModifierFlag;
-import com.contentgrid.appserver.application.model.searchfilters.AttributeSearchFilter;
 import com.contentgrid.appserver.application.model.searchfilters.BaseAttributeSearchFilter;
 import com.contentgrid.appserver.application.model.searchfilters.flags.HiddenSearchFilterFlag;
 import com.contentgrid.appserver.application.model.values.AttributePath;
@@ -118,6 +118,8 @@ public class ProfileAttributeRepresentationModelAssembler {
             case UniqueConstraint ignored -> ProfileAttributeConstraintRepresentationModel.unique();
             case AllowedValuesConstraint allowedValuesConstraint ->
                 ProfileAttributeConstraintRepresentationModel.allowedValues(allowedValuesConstraint.getValues());
+            case RegexPatternConstraint regexPatternConstraint ->
+                ProfileAttributeConstraintRepresentationModel.pattern(regexPatternConstraint.getHtmlPattern());
         };
     }
 

--- a/contentgrid-appserver-rest/src/main/java/com/contentgrid/appserver/rest/assembler/profile/json/JsonSchema.java
+++ b/contentgrid-appserver-rest/src/main/java/com/contentgrid/appserver/rest/assembler/profile/json/JsonSchema.java
@@ -262,29 +262,15 @@ public class JsonSchema {
         }
 
         /**
-         * Configures the {@link JsonSchemaProperty} to require the given regular expression as pattern.
-         *
-         * @param regex must not be {@literal null}.
-         * @return
-         */
-        public JsonSchemaProperty withRegex(String regex) {
-
-            Assert.hasText(regex, "Regular expression must not be null or empty");
-            return withPattern(Pattern.compile(regex));
-        }
-
-        /**
          * Configures the {@link JsonSchemaProperty} to require the given {@link Pattern}.
          *
          * @param pattern must not be {@literal null}.
          * @return
          */
-        public JsonSchemaProperty withPattern(Pattern pattern) {
+        public JsonSchemaProperty withPattern(String pattern) {
 
-            Assert.notNull(pattern, "Pattern must not be null");
-
-            this.pattern = pattern.toString();
-            return withType(JsonSchemaType.STRING);
+            this.pattern = pattern;
+            return this;
         }
 
         /**

--- a/contentgrid-appserver-rest/src/main/java/com/contentgrid/appserver/rest/assembler/profile/json/JsonSchemaAssembler.java
+++ b/contentgrid-appserver-rest/src/main/java/com/contentgrid/appserver/rest/assembler/profile/json/JsonSchemaAssembler.java
@@ -2,6 +2,7 @@ package com.contentgrid.appserver.rest.assembler.profile.json;
 
 import com.contentgrid.appserver.application.model.Application;
 import com.contentgrid.appserver.application.model.Constraint.AllowedValuesConstraint;
+import com.contentgrid.appserver.application.model.Constraint.RegexPatternConstraint;
 import com.contentgrid.appserver.application.model.Constraint.RequiredConstraint;
 import com.contentgrid.appserver.application.model.Entity;
 import com.contentgrid.appserver.application.model.attributes.Attribute;
@@ -95,6 +96,12 @@ public class JsonSchemaAssembler {
             property = new EnumProperty(property.getName(), property.getTitle(), values, property.getDescription(),
                     property.isRequired());
         }
+
+        if(simpleAttribute.hasConstraint(RegexPatternConstraint.class)) {
+            var htmlPattern = simpleAttribute.getConstraint(RegexPatternConstraint.class).orElseThrow().getHtmlPattern();
+            property = property.withPattern(htmlPattern);
+        }
+
         return property;
     }
 

--- a/contentgrid-appserver-rest/src/main/java/com/contentgrid/appserver/rest/hal/forms/HalFormsTemplateGenerator.java
+++ b/contentgrid-appserver-rest/src/main/java/com/contentgrid/appserver/rest/hal/forms/HalFormsTemplateGenerator.java
@@ -2,6 +2,7 @@ package com.contentgrid.appserver.rest.hal.forms;
 
 import com.contentgrid.appserver.application.model.Application;
 import com.contentgrid.appserver.application.model.Constraint.AllowedValuesConstraint;
+import com.contentgrid.appserver.application.model.Constraint.RegexPatternConstraint;
 import com.contentgrid.appserver.application.model.Constraint.RequiredConstraint;
 import com.contentgrid.appserver.application.model.Entity;
 import com.contentgrid.appserver.application.model.attributes.Attribute;
@@ -255,7 +256,8 @@ public class HalFormsTemplateGenerator {
         var property = HalFormsProperty.named(prefixed.name())
                 .withPrompt(prefixed.prompt())
                 .withAttributeType(attribute.getType())
-                .withRequired(attribute.hasConstraint(RequiredConstraint.class));
+                .withRequired(attribute.hasConstraint(RequiredConstraint.class))
+                .withRegex(attribute.getConstraint(RegexPatternConstraint.class).map(RegexPatternConstraint::getHtmlPattern).orElse(null));
         return addAllowedValues(property, attribute, false);
     }
 

--- a/contentgrid-appserver-rest/src/main/java/com/contentgrid/appserver/rest/problem/ProblemDetailsExceptionHandler.java
+++ b/contentgrid-appserver-rest/src/main/java/com/contentgrid/appserver/rest/problem/ProblemDetailsExceptionHandler.java
@@ -7,6 +7,7 @@ import com.contentgrid.appserver.domain.data.InvalidPropertyDataException;
 import com.contentgrid.appserver.domain.data.type.DataType;
 import com.contentgrid.appserver.domain.data.validation.AllowedValuesConstraintViolationInvalidDataException;
 import com.contentgrid.appserver.domain.data.validation.ContentMissingInvalidDataException;
+import com.contentgrid.appserver.domain.data.validation.RegexPatternConstraintViolationInvalidDataException;
 import com.contentgrid.appserver.domain.data.validation.RequiredConstraintViolationInvalidDataException;
 import com.contentgrid.appserver.domain.paging.cursor.CursorCodec.CursorDecodeException;
 import com.contentgrid.appserver.domain.values.EntityIdentity;
@@ -91,6 +92,10 @@ public class ProblemDetailsExceptionHandler {
                         case AllowedValuesConstraintViolationInvalidDataException allowedValuesConstraintViolation -> problemFactory.createProblem(ProblemType.INPUT_VALIDATION_ALLOWED_VALUES, allowedValuesConstraintViolation.getAllowedValues())
                                 .withProperties(Map.of(
                                         "allowed_values", allowedValuesConstraintViolation.getAllowedValues()
+                                ));
+                        case RegexPatternConstraintViolationInvalidDataException regexPatternConstraintViolationInvalidDataException -> problemFactory.createProblem(ProblemType.INPUT_VALIDATION_PATTERN, regexPatternConstraintViolationInvalidDataException.getPattern().pattern())
+                                .withProperties(Map.of(
+                                        "pattern", regexPatternConstraintViolationInvalidDataException.getPattern().pattern()
                                 ));
                         // All exception types should be covered above, this is a fallback for when there are additional
                         // exceptions added without adding a case.

--- a/contentgrid-appserver-rest/src/main/java/com/contentgrid/appserver/rest/problem/ProblemType.java
+++ b/contentgrid-appserver-rest/src/main/java/com/contentgrid/appserver/rest/problem/ProblemType.java
@@ -12,6 +12,7 @@ public enum ProblemType implements ProblemTypeResolvable {
     INPUT_VALIDATION_INVALID_TYPE_FORMAT("input", "validation", "type", "format"),
     INPUT_VALIDATION_REQUIRED_VALUE("input", "validation", "required"),
     INPUT_VALIDATION_ALLOWED_VALUES("input", "validation", "allowed-values"),
+    INPUT_VALIDATION_PATTERN("input", "validation", "pattern"),
     INPUT_VALIDATION_NO_CONTENT("input", "validation", "no-content"),
     INPUT_VALIDATION_MISSING_RELATION_TARGET("input", "validation", "missing-relation-target"),
 

--- a/contentgrid-appserver-rest/src/main/resources/com/contentgrid/appserver/rest/problem/messages.properties
+++ b/contentgrid-appserver-rest/src/main/resources/com/contentgrid/appserver/rest/problem/messages.properties
@@ -13,6 +13,8 @@ com.contentgrid.appserver.rest.problem.ProblemType.title.input.validation.requir
 com.contentgrid.appserver.rest.problem.ProblemType.detail.input.validation.required=A value must be present, but it is missing or empty
 com.contentgrid.appserver.rest.problem.ProblemType.title.input.validation.allowed-values=Value is not allowed
 com.contentgrid.appserver.rest.problem.ProblemType.detail.input.validation.allowed-values=The value must be one of the allowed values {0}
+com.contentgrid.appserver.rest.problem.ProblemType.title.input.validation.pattern=Value is not allowed
+com.contentgrid.appserver.rest.problem.ProblemType.detail.input.validation.pattern=The value must match the pattern ''{0}''
 com.contentgrid.appserver.rest.problem.ProblemType.title.input.validation.no-content=No content present
 com.contentgrid.appserver.rest.problem.ProblemType.detail.input.validation.no-content=Content attributes can not be set when there is no content present
 com.contentgrid.appserver.rest.problem.ProblemType.title.input.validation.missing-relation-target=Relation target not found

--- a/contentgrid-appserver-rest/src/test/java/com/contentgrid/appserver/rest/EntityRestControllerTest.java
+++ b/contentgrid-appserver-rest/src/test/java/com/contentgrid/appserver/rest/EntityRestControllerTest.java
@@ -42,6 +42,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Random;
 import java.util.UUID;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterEach;
@@ -401,7 +402,7 @@ class EntityRestControllerTest {
         void failToCreateEntityWithLongForBoolean(MediaTypeConfiguration mediaTypeConfiguration) throws Exception {
             var person = createPerson();
             mockMvc.perform(mediaTypeConfiguration.configure(post("/invoices"), Map.of(
-                                    "number", UUID.randomUUID().toString(),
+                                    "number", String.valueOf(new Random().nextLong(0, Long.MAX_VALUE)),
                                     "amount", 123,
                                     "confidentiality", "public",
                                     "customer", Objects.requireNonNull(person.getRedirectedUrl()),
@@ -468,6 +469,28 @@ class EntityRestControllerTest {
                             )
                     );
         }
+
+        @ParameterizedTest
+        @MethodSource("com.contentgrid.appserver.rest.EntityRestControllerTest#supportedMediaTypes")
+        void testFailToCreateWithRegexMismatch(MediaTypeConfiguration mediaTypeConfiguration) throws Exception {
+            var person = createPerson();
+            mockMvc.perform(mediaTypeConfiguration.configure(post("/invoices"), Map.of(
+                                    "number", "non-matching-value",
+                                    "amount", 123,
+                                    "confidentiality", "public",
+                                    "customer", Objects.requireNonNull(person.getRedirectedUrl())
+                            ))
+                    ).andExpect(status().isBadRequest())
+                    .andExpect(ProblemDetailsMockMvcMatchers.validationConstraintViolation()
+                            .withError(e -> e.withType("https://contentgrid.cloud/problems/input/validation/pattern")
+                                    .withTitle("Value is not allowed")
+                                    .withDetail("The value must match the pattern '[0-9]+'")
+                                    .withField("pattern", "[0-9]+")
+                                    .withField("field", "number")
+                            )
+                    );
+        }
+
 
         @ParameterizedTest
         @MethodSource("com.contentgrid.appserver.rest.EntityRestControllerTest#supportedMediaTypes")
@@ -910,7 +933,7 @@ class EntityRestControllerTest {
 
         static Stream<Arguments> testListEntityInstances_withQueryParam() {
             return Stream.of(
-                    Arguments.of("?number=invoice1", 1),
+                    Arguments.of("?number=1", 1),
                     Arguments.of("?amount=12.0", 1),
                     Arguments.of("?amount~gt=10.0&amount~lt=20.0", 1),
                     Arguments.of("?amount~gte=12.0&amount~lte=12.5", 1),
@@ -923,9 +946,9 @@ class EntityRestControllerTest {
                     Arguments.of("?customer=00000000-0000-0000-0000-000000000000", 0),
                     Arguments.of("?customer.name~prefix=a", 1),
                     Arguments.of("?customer.vat=vat1", 1),
-                    Arguments.of("?previous_invoice.number=invoice1", 1),
+                    Arguments.of("?previous_invoice.number=1", 1),
                     Arguments.of("?previous_invoice.confidentiality=confidential", 1),
-                    Arguments.of("?next_invoice.number=invoice2", 1),
+                    Arguments.of("?next_invoice.number=2", 1),
                     Arguments.of("?next_invoice.confidentiality=public", 1)
             );
         }
@@ -950,7 +973,7 @@ class EntityRestControllerTest {
             assertThat(person1link).isNotBlank();
 
             var invoice1 = new HashMap<String, Object>();
-            invoice1.put("number", "invoice1");
+            invoice1.put("number", "1");
             invoice1.put("amount", 12.0);
             invoice1.put("received", "2025-01-01");
             invoice1.put("pay_before", "2026-01-01");
@@ -987,7 +1010,7 @@ class EntityRestControllerTest {
             assertThat(person2link).isNotBlank();
 
             var invoice2 = new HashMap<String, Object>();
-            invoice2.put("number", "invoice2");
+            invoice2.put("number", "2");
             invoice2.put("amount", 20.0);
             invoice2.put("received", "2025-01-02");
             invoice2.put("pay_before", "2025-01-31");

--- a/contentgrid-appserver-rest/src/test/java/com/contentgrid/appserver/rest/PermissionsPropagationTest.java
+++ b/contentgrid-appserver-rest/src/test/java/com/contentgrid/appserver/rest/PermissionsPropagationTest.java
@@ -27,6 +27,7 @@ import java.util.Arrays;
 import java.util.Base64;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Random;
 import java.util.UUID;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterEach;
@@ -163,7 +164,7 @@ class PermissionsPropagationTest {
                         .file(new MockMultipartFile("content", "my-file.pdf", "application/pdf", new byte[12]))
                         .header("X-ABAC-Context", encodeThunk(Scalar.of(true)))
                         .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                        .param("number", UUID.randomUUID().toString())
+                        .param("number", String.valueOf(randomNumber()))
                         .param("amount", amount.toPlainString())
                         .param("confidentiality", "public")
                         .param("customer", createPerson())
@@ -221,7 +222,7 @@ class PermissionsPropagationTest {
         mockMvc.perform(post("/invoices")
                 .header("X-ABAC-Context", abacContext)
                 .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                .param("number", UUID.randomUUID().toString())
+                .param("number", String.valueOf(randomNumber()))
                 .param("amount", AMOUNT_THRESHOLD_FOR_TEST.toPlainString())
                 .param("confidentiality", "public")
                 .param("customer", createPerson())
@@ -249,7 +250,7 @@ class PermissionsPropagationTest {
         var invoice = createInvoice(AMOUNT_THRESHOLD_FOR_TEST);
 
         var content = Map.of(
-                "number", UUID.randomUUID().toString(),
+                "number", String.valueOf(randomNumber()),
                 "amount", AMOUNT_THRESHOLD_ALWAYS_ALLOWED.toPlainString(),
                 "confidentiality", "public"
         );
@@ -259,6 +260,10 @@ class PermissionsPropagationTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsBytes(content))
         ).andExpect(isAllowed ? status().is2xxSuccessful():status().isForbidden());
+    }
+
+    private long randomNumber() {
+        return new Random().nextLong(0, Long.MAX_VALUE);
     }
 
     @ParameterizedTest
@@ -272,7 +277,7 @@ class PermissionsPropagationTest {
         var invoice = createInvoice(AMOUNT_THRESHOLD_ALWAYS_ALLOWED);
 
         var content = Map.of(
-                "number", UUID.randomUUID().toString(),
+                "number", String.valueOf(randomNumber()),
                 "amount", AMOUNT_THRESHOLD_FOR_TEST.toPlainString(),
                 "confidentiality", "public"
         );

--- a/contentgrid-appserver-rest/src/test/java/com/contentgrid/appserver/rest/ProfileRestControllerTest.java
+++ b/contentgrid-appserver-rest/src/test/java/com/contentgrid/appserver/rest/ProfileRestControllerTest.java
@@ -119,6 +119,9 @@ class ProfileRestControllerTest {
                                             type: "required"
                                         }, {
                                             type: "unique"
+                                        }, {
+                                            type: "pattern",
+                                            pattern: "[0-9]+"
                                         }],
                                         "blueprint:search-param": [{
                                             name: "number",

--- a/contentgrid-appserver-rest/src/test/java/com/contentgrid/appserver/rest/hal/forms/HalFormsTemplateGeneratorTest.java
+++ b/contentgrid-appserver-rest/src/test/java/com/contentgrid/appserver/rest/hal/forms/HalFormsTemplateGeneratorTest.java
@@ -322,7 +322,7 @@ class HalFormsTemplateGeneratorTest {
                     assertThat(contentMimetype.getPrompt()).isEqualTo("content: Mimetype");
                     assertThat(contentMimetype.isReadOnly()).isFalse();
                     assertThat(contentMimetype.isRequired()).isFalse();
-                    assertThat(contentMimetype.getRegex()).isNotEmpty();
+                    assertThat(contentMimetype.getRegex()).hasSizeGreaterThan(10).hasSizeLessThan(1024); // Ensure that we're sending the correct regex, but not multiple kilobytes of data
                     assertThat(contentMimetype.getType()).isEqualTo(HtmlInputType.TEXT_VALUE);
                 }
         );

--- a/contentgrid-appserver-rest/src/test/java/com/contentgrid/appserver/rest/hal/forms/HalFormsTemplateGeneratorTest.java
+++ b/contentgrid-appserver-rest/src/test/java/com/contentgrid/appserver/rest/hal/forms/HalFormsTemplateGeneratorTest.java
@@ -322,6 +322,7 @@ class HalFormsTemplateGeneratorTest {
                     assertThat(contentMimetype.getPrompt()).isEqualTo("content: Mimetype");
                     assertThat(contentMimetype.isReadOnly()).isFalse();
                     assertThat(contentMimetype.isRequired()).isFalse();
+                    assertThat(contentMimetype.getRegex()).isNotEmpty();
                     assertThat(contentMimetype.getType()).isEqualTo(HtmlInputType.TEXT_VALUE);
                 }
         );

--- a/contentgrid-appserver-rest/src/test/java/com/contentgrid/appserver/rest/hal/forms/HalFormsTemplateGeneratorTest.java
+++ b/contentgrid-appserver-rest/src/test/java/com/contentgrid/appserver/rest/hal/forms/HalFormsTemplateGeneratorTest.java
@@ -58,6 +58,7 @@ class HalFormsTemplateGeneratorTest {
                     assertThat(number.getName()).isEqualTo("number");
                     assertThat(number.isReadOnly()).isFalse();
                     assertThat(number.isRequired()).isTrue();
+                    assertThat(number.getRegex()).isEqualTo("[0-9]+");
                     assertThat(number.getType()).isEqualTo(HtmlInputType.TEXT_VALUE);
                 },
                 amount -> {
@@ -261,6 +262,7 @@ class HalFormsTemplateGeneratorTest {
                     assertThat(number.getName()).isEqualTo("number");
                     assertThat(number.isReadOnly()).isFalse();
                     assertThat(number.isRequired()).isTrue();
+                    assertThat(number.getRegex()).isEqualTo("[0-9]+");
                     assertThat(number.getType()).isEqualTo(HtmlInputType.TEXT_VALUE);
                 },
                 amount -> {
@@ -339,6 +341,7 @@ class HalFormsTemplateGeneratorTest {
                 number -> {
                     assertThat(number.getName()).isEqualTo("number");
                     assertThat(number.getType()).isEqualTo(HtmlInputType.TEXT_VALUE);
+                    assertThat(number.getRegex()).isNull(); // No regex on the search field
                 },
                 amount -> {
                     assertThat(amount.getName()).isEqualTo("amount");
@@ -424,6 +427,7 @@ class HalFormsTemplateGeneratorTest {
                 previousNumber -> {
                     assertThat(previousNumber.getName()).isEqualTo("previous_invoice.number");
                     assertThat(previousNumber.getType()).isEqualTo(HtmlInputType.TEXT_VALUE);
+                    assertThat(previousNumber.getRegex()).isNull();
                 },
                 previousConfidentiality -> {
                     assertThat(previousConfidentiality.getName()).isEqualTo("previous_invoice.confidentiality");
@@ -441,6 +445,7 @@ class HalFormsTemplateGeneratorTest {
                 nextNumber -> {
                     assertThat(nextNumber.getName()).isEqualTo("next_invoice.number");
                     assertThat(nextNumber.getType()).isEqualTo(HtmlInputType.TEXT_VALUE);
+                    assertThat(nextNumber.getRegex()).isNull();
                 },
                 nextConfidentiality -> {
                     assertThat(nextConfidentiality.getName()).isEqualTo("next_invoice.confidentiality");
@@ -550,6 +555,7 @@ class HalFormsTemplateGeneratorTest {
                 invoicesNumber -> {
                     assertThat(invoicesNumber.getName()).isEqualTo("invoices.number");
                     assertThat(invoicesNumber.getType()).isEqualTo(HtmlInputType.TEXT_VALUE);
+                    assertThat(invoicesNumber.getRegex()).isNull(); // no regex on the search fields
                 },
                 invoicesConfidentiality -> {
                     assertThat(invoicesConfidentiality.getName()).isEqualTo("invoices.confidentiality");

--- a/contentgrid-appserver-rest/src/test/java/com/contentgrid/appserver/rest/property/ContentRestControllerTest.java
+++ b/contentgrid-appserver-rest/src/test/java/com/contentgrid/appserver/rest/property/ContentRestControllerTest.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.InputStream;
 import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
+import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.CompletionException;
 import java.util.stream.Stream;
@@ -114,7 +115,7 @@ class ContentRestControllerTest {
     }
 
     private String createInvoice(MockMultipartFile contentFile) throws Exception {
-        String invoiceNumber = "INV-" + UUID.randomUUID().toString().substring(0, 8);
+        String invoiceNumber = String.valueOf(new Random().nextLong(0, Long.MAX_VALUE));
 
         var requestBuilder = multipart("/invoices");
         if (contentFile != null) {

--- a/contentgrid-appserver-rest/src/test/java/com/contentgrid/appserver/rest/property/RelationRestControllerTest.java
+++ b/contentgrid-appserver-rest/src/test/java/com/contentgrid/appserver/rest/property/RelationRestControllerTest.java
@@ -13,6 +13,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.contentgrid.appserver.application.model.Constraint.AllowedValuesConstraint;
+import com.contentgrid.appserver.application.model.Constraint.RegexPatternConstraint;
 import com.contentgrid.appserver.application.model.Constraint.RequiredConstraint;
 import com.contentgrid.appserver.application.model.Entity;
 import com.contentgrid.appserver.application.model.attributes.SimpleAttribute;
@@ -38,6 +39,7 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Random;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Stream;
@@ -130,6 +132,11 @@ class RelationRestControllerTest {
                 });
                 sa.getConstraint(AllowedValuesConstraint.class).ifPresent(allowedValues -> {
                     params.set(sa.getName().getValue(), allowedValues.getValues().getFirst());
+                });
+                sa.getConstraint(RegexPatternConstraint.class).ifPresent(regexPatternConstraint -> {
+                    if(regexPatternConstraint.getHtmlPattern().equals("[0-9]+")) {
+                        params.set(sa.getName().getValue(), String.valueOf(new Random().nextInt(0, Integer.MAX_VALUE)));
+                    }
                 });
             }
 


### PR DESCRIPTION
1. Add a generic 'pattern' constraint type that performs field validation using regex
2. Add a specific 'pattern' constraint to the content mimetype field that checks for valid mimetypes
