### PR TITLE
ACC-2571: publish docker image to ghcr.io

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ github.token }}
         run: ./gradlew sonar -i
-      - name: Publish
+      - name: Publish to maven central
         if: ${{ github.ref == 'refs/heads/main' || startswith(github.ref, 'refs/tags/') }}
         env:
           SIGNING_PRIVATE_KEY: ${{ secrets.MAVEN_CENTRAL_GPG_KEY }}
@@ -39,3 +39,10 @@ jobs:
           ORG_GRADLE_PROJECT_mavenCentralPublishUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPublishPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
         run: ./gradlew publish
+      - name: Publish to ghcr.io
+        if: ${{ github.ref == 'refs/heads/main' || startswith(github.ref, 'refs/tags/') }}
+        env:
+          ORG_GRADLE_PROJECT_DOCKER_PUBLISH_REGISTRY_URL: ghcr.io
+          ORG_GRADLE_PROJECT_DOCKER_PUBLISH_REGISTRY_USERNAME: ${{ github.actor }}
+          ORG_GRADLE_PROJECT_DOCKER_PUBLISH_REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+        run: ./gradlew bootBuildImage --publishImage

--- a/contentgrid-appserver-app/build.gradle
+++ b/contentgrid-appserver-app/build.gradle
@@ -20,3 +20,21 @@ bootRun {
     classpath += sourceSets.testFixtures.output
     classpath += configurations.testFixturesRuntimeClasspath
 }
+
+bootBuildImage {
+    def dockerImageRepo = "ghcr.io/xenit-eu/contentgrid-appserver"
+    imageName = "${dockerImageRepo}:${project.version}"
+    tags = "${project.version}".endsWith('SNAPSHOT') ? [ "${dockerImageRepo}:SNAPSHOT" ] : null
+
+    if (!ci.isCi()) {
+        tags.add("${dockerImageRepo}:local")
+    }
+
+    docker {
+        publishRegistry {
+            url = project.findProperty('DOCKER_PUBLISH_REGISTRY_URL')
+            username = project.findProperty('DOCKER_PUBLISH_REGISTRY_USERNAME')
+            password = project.findProperty('DOCKER_PUBLISH_REGISTRY_PASSWORD')
+        }
+    }
+}

--- a/contentgrid-appserver-app/src/main/resources/application.yml
+++ b/contentgrid-appserver-app/src/main/resources/application.yml
@@ -7,6 +7,5 @@ spring:
       max-file-size: -1
       max-request-size: -1
 server:
-  port: ${PORT:8080}
   tomcat:
     max-part-count: 200

--- a/contentgrid-appserver-app/src/testFixtures/resources/application-bootRun.yml
+++ b/contentgrid-appserver-app/src/testFixtures/resources/application-bootRun.yml
@@ -23,6 +23,8 @@ spring:
     url: jdbc:tc:postgresql:15:///
   autoconfigure:
     exclude: org.springframework.boot.autoconfigure.amqp.RabbitAutoConfiguration
+server:
+  port: ${PORT:8080}
 
 management:
   endpoints:


### PR DESCRIPTION
requires #279 first, then this needs rework.

Changes between a generated app:
- build.gradle: no `org.testcontainers:postgresql` implementation dependency
- application.yml: only application properties for problemdetails, multipart uploads and tomcat max-part-count.
- application-initContainer.yml: _no difference_