### PR TITLE
ACC-2941 Re-enable prometheus actuator endpoint

### DIFF
--- a/contentgrid-appserver-app/build.gradle
+++ b/contentgrid-appserver-app/build.gradle
@@ -13,6 +13,7 @@ dependencies {
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.hamcrest:hamcrest'
+    testRuntimeOnly 'io.micrometer:micrometer-registry-prometheus'
 }
 
 bootRun {

--- a/contentgrid-appserver-app/src/test/java/com/contentgrid/appserver/example/ContentgridPrometheusActuatorTest.java
+++ b/contentgrid-appserver-app/src/test/java/com/contentgrid/appserver/example/ContentgridPrometheusActuatorTest.java
@@ -1,17 +1,12 @@
 package com.contentgrid.appserver.example;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
 
-import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.SpringApplication;
-import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
-import org.springframework.context.ApplicationContext;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.ActiveProfiles;
 
@@ -24,7 +19,7 @@ import org.springframework.test.context.ActiveProfiles;
         }
 )
 @ActiveProfiles("bootRun")
-public class ContentgridPrometheusActuatorTest {
+class ContentgridPrometheusActuatorTest {
     @Autowired
     private TestRestTemplate rest;
 

--- a/contentgrid-appserver-app/src/test/java/com/contentgrid/appserver/example/ContentgridPrometheusActuatorTest.java
+++ b/contentgrid-appserver-app/src/test/java/com/contentgrid/appserver/example/ContentgridPrometheusActuatorTest.java
@@ -24,7 +24,6 @@ import org.springframework.test.context.ActiveProfiles;
         }
 )
 @ActiveProfiles("bootRun")
-@Slf4j
 public class ContentgridPrometheusActuatorTest {
     @Autowired
     private TestRestTemplate rest;
@@ -32,17 +31,9 @@ public class ContentgridPrometheusActuatorTest {
     @Value("${local.management.port}")
     int managementPort;
 
-    @SpringBootApplication
-    static class TestApplication {
-        public static void main(String[] args) {
-            SpringApplication.run(TestApplication.class, args);
-        }
-    }
-
     @Test
     void prometheusEndpointIsPublic() {
         ResponseEntity<String> resp = rest.getForEntity("http://localhost:" + managementPort + "/actuator/prometheus", String.class);
-        log.debug(resp.toString());
         assertThat(resp.getStatusCode().is2xxSuccessful()).isTrue();
     }
 }

--- a/contentgrid-appserver-app/src/test/java/com/contentgrid/appserver/example/ContentgridPrometheusActuatorTest.java
+++ b/contentgrid-appserver-app/src/test/java/com/contentgrid/appserver/example/ContentgridPrometheusActuatorTest.java
@@ -1,0 +1,48 @@
+package com.contentgrid.appserver.example;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.context.ApplicationContext;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest(
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+        properties = {
+                "management.endpoints.web.exposure.include=*",
+                "management.prometheus.metrics.export.enabled=true", //bootRun profile disables metrics, which is fine for other tests but should be overridden here
+                "management.server.port=0" // random, different port from main port
+        }
+)
+@ActiveProfiles("bootRun")
+@Slf4j
+public class ContentgridPrometheusActuatorTest {
+    @Autowired
+    private TestRestTemplate rest;
+
+    @Value("${local.management.port}")
+    int managementPort;
+
+    @SpringBootApplication
+    static class TestApplication {
+        public static void main(String[] args) {
+            SpringApplication.run(TestApplication.class, args);
+        }
+    }
+
+    @Test
+    void prometheusEndpointIsPublic() {
+        ResponseEntity<String> resp = rest.getForEntity("http://localhost:" + managementPort + "/actuator/prometheus", String.class);
+        log.debug(resp.toString());
+        assertThat(resp.getStatusCode().is2xxSuccessful()).isTrue();
+    }
+}

--- a/contentgrid-appserver-spring-boot-starter/build.gradle
+++ b/contentgrid-appserver-spring-boot-starter/build.gradle
@@ -22,5 +22,6 @@ dependencies {
     implementation project(':contentgrid-appserver-webjars')
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
     implementation 'org.springframework.boot:spring-boot-starter-jooq'
+    runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
 
 }


### PR DESCRIPTION
This actuator bean is conditional on micrometer-registry classes being on the classpath. By including the added dependency as `runtimeOnly` we ensure this is the case, triggering the creation of the actuator bean.