### PR TITLE
ACC-2639: simplify disjunction in ThunkExpressionGenerator

### DIFF
--- a/contentgrid-appserver-domain/src/main/java/com/contentgrid/appserver/domain/ThunkExpressionGenerator.java
+++ b/contentgrid-appserver-domain/src/main/java/com/contentgrid/appserver/domain/ThunkExpressionGenerator.java
@@ -19,6 +19,7 @@ import com.contentgrid.appserver.query.engine.api.thunx.expression.StringCompari
 import com.contentgrid.thunx.predicates.model.Comparison;
 import com.contentgrid.thunx.predicates.model.LogicalOperation;
 import com.contentgrid.thunx.predicates.model.Scalar;
+import com.contentgrid.thunx.predicates.model.SetValue;
 import com.contentgrid.thunx.predicates.model.SymbolicReference;
 import com.contentgrid.thunx.predicates.model.SymbolicReference.PathElement;
 import com.contentgrid.thunx.predicates.model.ThunkExpression;
@@ -27,6 +28,7 @@ import java.math.BigDecimal;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
@@ -55,28 +57,19 @@ public class ThunkExpressionGenerator {
                 // currently only handle attribute search filters
                 if (searchFilter instanceof BaseAttributeSearchFilter attributeSearchFilter) {
                     var attribute = application.resolvePropertyPath(entity, attributeSearchFilter.getAttributePath());
-                    List<ThunkExpression<Boolean>> subexpressions = new ArrayList<>();
+                    List<Scalar<?>> parsedValues = new ArrayList<>();
 
                     for (String value : entry.getValue()) {
                         try {
-                            Scalar<?> parsedValue = parseValueToScalar(attribute.getType(), value);
-                            subexpressions.add(createExpression(
-                                    attributeSearchFilter,
-                                    convertPath(variableGenerator, application, entity, attributeSearchFilter.getAttributePath()),
-                                    parsedValue
-                            ));
+                            parsedValues.add(parseValueToScalar(attribute.getType(), value));
                         } catch (Exception e) {
                             throw new InvalidFilterParameterException(entity.getName(), attributeSearchFilter.getName(),
                                     attribute.getType(), e);
                         }
                     }
 
-                    if (subexpressions.size() == 1) {
-                        // If there's only one subexpression, add it directly
-                        expressions.add(subexpressions.getFirst());
-                    } else if (!subexpressions.isEmpty()) {
-                        // Otherwise, create a disjunction (OR) of all subexpressions if not empty
-                        expressions.add(LogicalOperation.disjunction(subexpressions));
+                    if (!parsedValues.isEmpty()) {
+                        expressions.add(createExpression(variableGenerator, application, entity, attributeSearchFilter, parsedValues));
                     }
                 }
             }
@@ -114,32 +107,87 @@ public class ThunkExpressionGenerator {
         };
     }
 
-    private static ThunkExpression<Boolean> createExpression(BaseAttributeSearchFilter filter,
-                                                             List<PathElement> pathElements,
-                                                             Scalar<?> value) throws IllegalArgumentException {
-        SymbolicReference attr = SymbolicReference.of(Variable.named("entity"), pathElements);
+    private static ThunkExpression<Boolean> createExpression(
+            VariableGenerator variableGenerator,
+            Application application,
+            Entity entity,
+            BaseAttributeSearchFilter filter,
+            List<Scalar<?>> values) {
 
-        if (filter instanceof FullTextSearchAttributeSearchFilter ftsSearchFilter) return createExpression(ftsSearchFilter, attr, value);
-        if (filter instanceof AttributeSearchFilter attrSearchFilter) return createExpression(attrSearchFilter, attr, value);
+        if (filter instanceof FullTextSearchAttributeSearchFilter ftsFilter) {
+            // FTS keeps a disjunction; each term gets its own path so to-many wildcards stay independent
+            var subexpressions = values.stream()
+                    .map(v -> (ThunkExpression<Boolean>) StringComparison.contentGridFullTextSearchMatch(
+                            symRef(convertPath(variableGenerator, application, entity, filter.getAttributePath())),
+                            v.assertResultType(String.class),
+                            ftsFilter.getLocale()
+                    ))
+                    .toList();
+            return toSingleOrDisjunction(subexpressions);
+        }
+
+        if (filter instanceof AttributeSearchFilter attrFilter) {
+            return switch (attrFilter.getOperation()) {
+                case EXACT -> {
+                    // EXACT can use in when there are multiple values
+                    var attr = symRef(convertPath(variableGenerator, application, entity, filter.getAttributePath()));
+                    yield values.size() == 1
+                            ? Comparison.areEqual(attr, values.getFirst())
+                            : Comparison.in(attr, new SetValue(new LinkedHashSet<>(values)));
+                }
+                case PREFIX -> {
+                    // PREFIX keeps a disjunction; each term gets its own path so to-many wildcards stay independent
+                    var subexpressions = values.stream()
+                            .map(v -> (ThunkExpression<Boolean>) StringComparison.contentGridPrefixSearchMatch(
+                                    symRef(convertPath(variableGenerator, application, entity, filter.getAttributePath())),
+                                    v.assertResultType(String.class)
+                            ))
+                            .toList();
+                    yield toSingleOrDisjunction(subexpressions);
+                }
+                // GREATER_THAN and GREATER_THAN_OR_EQUAL always compare with the minimum value
+                case GREATER_THAN -> Comparison.greater(
+                        symRef(convertPath(variableGenerator, application, entity, filter.getAttributePath())),
+                        minScalar(values));
+                case GREATER_THAN_OR_EQUAL -> Comparison.greaterOrEquals(
+                        symRef(convertPath(variableGenerator, application, entity, filter.getAttributePath())),
+                        minScalar(values));
+                // LESS_THAN and LESS_THAN_OR_EQUAL always compare with the maximum value
+                case LESS_THAN -> Comparison.less(
+                        symRef(convertPath(variableGenerator, application, entity, filter.getAttributePath())),
+                        maxScalar(values));
+                case LESS_THAN_OR_EQUAL -> Comparison.lessOrEquals(
+                        symRef(convertPath(variableGenerator, application, entity, filter.getAttributePath())),
+                        maxScalar(values));
+            };
+        }
 
         throw new IllegalArgumentException("Received unknown filter type (%s).".formatted(filter.getClass().getName()));
     }
 
-    private static ThunkExpression<Boolean> createExpression(AttributeSearchFilter filter, SymbolicReference attr, Scalar<?> value) {
-        return switch (filter.getOperation()) {
-            case EXACT -> Comparison.areEqual(attr, value);
-            case PREFIX -> StringComparison.contentGridPrefixSearchMatch(attr, value.assertResultType(String.class));
-            case GREATER_THAN -> Comparison.greater(attr, value);
-            case GREATER_THAN_OR_EQUAL -> Comparison.greaterOrEquals(attr, value);
-            case LESS_THAN -> Comparison.less(attr, value);
-            case LESS_THAN_OR_EQUAL -> Comparison.lessOrEquals(attr, value);
-        };
+    private static SymbolicReference symRef(List<PathElement> pathElements) {
+        return SymbolicReference.of(Variable.named("entity"), pathElements);
     }
 
-    private static ThunkExpression<Boolean> createExpression(FullTextSearchAttributeSearchFilter filter,
-                                                             SymbolicReference attr,
-                                                             Scalar<?> value) {
-        return StringComparison.contentGridFullTextSearchMatch(attr, value.assertResultType(String.class), filter.getLocale());
+    private static ThunkExpression<Boolean> toSingleOrDisjunction(List<ThunkExpression<Boolean>> subexpressions) {
+        if (subexpressions.size() == 1) {
+            return subexpressions.getFirst();
+        }
+        return LogicalOperation.disjunction(subexpressions);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Scalar<?> minScalar(List<Scalar<?>> values) {
+        return values.stream()
+                .min((a, b) -> ((Comparable<Object>) a.getValue()).compareTo(b.getValue()))
+                .orElseThrow();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Scalar<?> maxScalar(List<Scalar<?>> values) {
+        return values.stream()
+                .max((a, b) -> ((Comparable<Object>) a.getValue()).compareTo(b.getValue()))
+                .orElseThrow();
     }
 
     private static List<PathElement> convertPath(VariableGenerator variableGenerator, Application application, Entity entity, PropertyPath path) {

--- a/contentgrid-appserver-domain/src/test/java/com/contentgrid/appserver/domain/ThunkExpressionGeneratorTest.java
+++ b/contentgrid-appserver-domain/src/test/java/com/contentgrid/appserver/domain/ThunkExpressionGeneratorTest.java
@@ -3,6 +3,7 @@ package com.contentgrid.appserver.domain;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.contentgrid.appserver.application.model.Application;
 import com.contentgrid.appserver.application.model.Entity;
@@ -35,6 +36,7 @@ import com.contentgrid.thunx.predicates.model.Comparison;
 import com.contentgrid.thunx.predicates.model.FunctionExpression.Operator;
 import com.contentgrid.thunx.predicates.model.LogicalOperation;
 import com.contentgrid.thunx.predicates.model.Scalar;
+import com.contentgrid.thunx.predicates.model.SetValue;
 import com.contentgrid.thunx.predicates.model.SymbolicReference;
 import com.contentgrid.thunx.predicates.model.ThunkExpression;
 import com.contentgrid.thunx.predicates.model.Variable;
@@ -351,6 +353,11 @@ class ThunkExpressionGeneratorTest {
                     .name(FilterName.of("wishlist.description"))
                     .attributePath(PropertyPath.of(RelationName.of("wishlist"), AttributeName.of("description")))
                     .build())
+            .searchFilter(AttributeSearchFilter.builder()
+                    .operation(Operation.PREFIX)
+                    .name(FilterName.of("wishlist.description~prefix"))
+                    .attributePath(PropertyPath.of(RelationName.of("wishlist"), AttributeName.of("description")))
+                    .build())
             .build();
 
     private static final Relation shipmentRelation = ManyToOneRelation.builder()
@@ -504,7 +511,7 @@ class ThunkExpressionGeneratorTest {
     }
 
     @Test
-    void MultipleParametersMultipleValuesShouldCreateConjunctionOfDisjunctions() {
+    void multipleParametersMultipleValuesShouldCreateConjunctionWithOptimizedTerms() {
         Map<String, List<String>> params = new HashMap<>();
         params.put("description~prefix", List.of("foo", "bar"));
         params.put("count", List.of("0", "1"));
@@ -514,11 +521,22 @@ class ThunkExpressionGeneratorTest {
         var operation = assertInstanceOf(LogicalOperation.class, result);
         assertEquals(Operator.AND, operation.getOperator());
         assertEquals(2, operation.getTerms().size());
-        operation.getTerms().forEach(term -> {
-            var innerOperation = assertInstanceOf(LogicalOperation.class, term);
-            assertEquals(Operator.OR, innerOperation.getOperator());
-            assertEquals(2, innerOperation.getTerms().size());
-        });
+
+        // PREFIX uses a disjunction (no single-expression optimization available)
+        var prefixTerm = operation.getTerms().stream()
+                .filter(t -> t instanceof LogicalOperation lo && lo.getOperator() == Operator.OR)
+                .findFirst().orElseThrow();
+        var orOp = assertInstanceOf(LogicalOperation.class, prefixTerm);
+        assertEquals(2, orOp.getTerms().size());
+        orOp.getTerms().forEach(t -> assertInstanceOf(ContentGridPrefixSearch.class, t));
+
+        // EXACT with multiple values uses IN
+        var inTerm = operation.getTerms().stream()
+                .filter(t -> t instanceof Comparison c && c.getOperator() == Operator.IN)
+                .findFirst().orElseThrow();
+        var inComparison = assertInstanceOf(Comparison.class, inTerm);
+        var setValue = assertInstanceOf(SetValue.class, inComparison.getRightTerm());
+        assertEquals(2, setValue.getValue().size());
     }
 
     @ParameterizedTest
@@ -867,13 +885,74 @@ class ThunkExpressionGeneratorTest {
     }
 
     @Test
-    void multipleValuesToManyRelationUseDifferentWildCards() {
-        // TODO: currently uses OR, but should use IN after ACC-2639 (and then there are no wildcards anymore)
+    void multipleValuesExactShouldUseIn() {
+        Map<String, List<String>> params = new HashMap<>();
+        params.put("count", List.of("1", "2", "3"));
+
+        ThunkExpression<Boolean> result = ThunkExpressionGenerator.from(testApplication, testEntity, params);
+
+        var comparison = assertInstanceOf(Comparison.class, result);
+        assertEquals(Operator.IN, comparison.getOperator());
+        var setValue = assertInstanceOf(SetValue.class, comparison.getRightTerm());
+        assertEquals(3, setValue.getValue().size());
+        assertTrue(setValue.getValue().contains(Scalar.of(1L)));
+        assertTrue(setValue.getValue().contains(Scalar.of(2L)));
+        assertTrue(setValue.getValue().contains(Scalar.of(3L)));
+    }
+
+    @Test
+    void multipleValuesGreaterThanShouldUseMinimum() {
+        Map<String, List<String>> params = new HashMap<>();
+        params.put("count~gt", List.of("10", "5", "20"));
+
+        ThunkExpression<Boolean> result = ThunkExpressionGenerator.from(testApplication, testEntity, params);
+
+        var comparison = assertInstanceOf(Comparison.class, result);
+        assertEquals(Operator.GREATER_THAN, comparison.getOperator());
+        assertEquals(new BigDecimal("5"), ((Scalar<?>) comparison.getRightTerm()).getValue());
+    }
+
+    @Test
+    void multipleValuesLessThanShouldUseMaximum() {
+        Map<String, List<String>> params = new HashMap<>();
+        params.put("count~lt", List.of("10", "5", "20"));
+
+        ThunkExpression<Boolean> result = ThunkExpressionGenerator.from(testApplication, testEntity, params);
+
+        var comparison = assertInstanceOf(Comparison.class, result);
+        assertEquals(Operator.LESS_THAN, comparison.getOperator());
+        assertEquals(new BigDecimal("20"), ((Scalar<?>) comparison.getRightTerm()).getValue());
+    }
+
+    @Test
+    void multipleExactValuesToManyRelationUsesInWithSingleWildcard() {
         Map<String, List<String>> params = Map.of(
                 "shipments.destination", List.of("Moon Base", "Middle Earth")
         );
-        var entity = testApplication.getEntityByName(EntityName.of("customer")).orElseThrow();
-        ThunkExpression<Boolean> result = ThunkExpressionGenerator.from(testApplication, entity, params);
+        ThunkExpression<Boolean> result = ThunkExpressionGenerator.from(testApplication, customerEntity, params);
+
+        var comparison = assertInstanceOf(Comparison.class, result);
+        assertEquals(Operator.IN, comparison.getOperator());
+        assertEquals(
+                SymbolicReference.of(
+                        Variable.named("entity"),
+                        SymbolicReference.path("shipments"),
+                        SymbolicReference.pathVar("__wildcard_0"),
+                        SymbolicReference.path("destination")
+                ),
+                comparison.getLeftTerm()
+        );
+        var setValue = assertInstanceOf(SetValue.class, comparison.getRightTerm());
+        assertTrue(setValue.getValue().contains(Scalar.of("Moon Base")));
+        assertTrue(setValue.getValue().contains(Scalar.of("Middle Earth")));
+    }
+
+    @Test
+    void multiplePrefixValuesToManyRelationUseDifferentWildCards() {
+        Map<String, List<String>> params = Map.of(
+                "wishlist.description~prefix", List.of("foo", "bar")
+        );
+        ThunkExpression<Boolean> result = ThunkExpressionGenerator.from(testApplication, customerEntity, params);
         var logicalOperation = assertInstanceOf(LogicalOperation.class, result);
         assertEquals(Operator.OR, logicalOperation.getOperator());
         assertEquals(2, logicalOperation.getTerms().size());
@@ -883,18 +962,18 @@ class ThunkExpressionGeneratorTest {
         assertEquals(
                 SymbolicReference.of(
                         Variable.named("entity"),
-                        SymbolicReference.path("shipments"),
+                        SymbolicReference.path("wishlist"),
                         SymbolicReference.pathVar("__wildcard_0"),
-                        SymbolicReference.path("destination")
+                        SymbolicReference.path("description")
                 ),
                 left.getLeftTerm()
         );
         assertEquals(
                 SymbolicReference.of(
                         Variable.named("entity"),
-                        SymbolicReference.path("shipments"),
+                        SymbolicReference.path("wishlist"),
                         SymbolicReference.pathVar("__wildcard_1"),
-                        SymbolicReference.path("destination")
+                        SymbolicReference.path("description")
                 ),
                 right.getLeftTerm()
         );


### PR DESCRIPTION
When multiple query parameters are provided for the same query parameter, they are combined as disjunction (OR), simplify the disjunction for the following cases:
- `FTS` and `PREFIX`: cannot simplify → keep disjucntion
- `EXACT`: `foo = "a" OR foo = "b"` → `foo in ["a", "b"]`
- `GREATER_THAN` and `GREATER_THAN_OR_EQUAL`: `foo > 2 OR foo > 10` → `foo > min(2, 10)` → `foo > 2`
- `LESS_THAN` and `LESS_THAN_OR_EQUAL`: `foo < 2 OR foo < 10` → `foo < max(2, 10)` → `foo < 10`