### PR TITLE
ACC-2742 Add rabbitmq to health check

### DIFF
--- a/contentgrid-appserver-app/src/main/resources/application.yml
+++ b/contentgrid-appserver-app/src/main/resources/application.yml
@@ -9,3 +9,9 @@ spring:
 server:
   tomcat:
     max-part-count: 200
+management:
+  server:
+    port: 8081
+  health:
+    rabbit:
+      enabled: true


### PR DESCRIPTION
If contentgrid.events.rabbitmq.enabled is false, rabbit health actuator will also not start and wont affect the global application health check.