### PR TITLE
ACC-3028: configure database schema with DatabaseSettings

### DIFF
--- a/contentgrid-appserver-application-model-json/src/main/java/com/contentgrid/appserver/application/model/json/DefaultApplicationSchemaConverter.java
+++ b/contentgrid-appserver-application-model-json/src/main/java/com/contentgrid/appserver/application/model/json/DefaultApplicationSchemaConverter.java
@@ -2,7 +2,6 @@ package com.contentgrid.appserver.application.model.json;
 
 import com.contentgrid.appserver.application.model.Application;
 import com.contentgrid.appserver.application.model.Constraint;
-import com.contentgrid.appserver.application.model.json.model.ApplicationSettings;
 import com.contentgrid.appserver.application.model.settings.encryption.ContentEncryptionEngineAlgorithm;
 import com.contentgrid.appserver.application.model.settings.encryption.ContentEncryptionKeyWrapperAlgorithm;
 import com.contentgrid.appserver.application.model.Entity.ConfigurableEntityTranslations;
@@ -48,6 +47,7 @@ import com.contentgrid.appserver.application.model.values.PathSegmentName;
 import com.contentgrid.appserver.application.model.values.PropertyName;
 import com.contentgrid.appserver.application.model.values.PropertyPath;
 import com.contentgrid.appserver.application.model.values.RelationName;
+import com.contentgrid.appserver.application.model.values.SchemaName;
 import com.contentgrid.appserver.application.model.values.SortableName;
 import com.contentgrid.appserver.application.model.values.TableName;
 import com.contentgrid.appserver.application.model.json.exceptions.InvalidJsonException;
@@ -56,10 +56,12 @@ import com.contentgrid.appserver.application.model.json.exceptions.UnknownFlagEx
 import com.contentgrid.appserver.application.model.json.model.AllowedValuesConstraint;
 import com.contentgrid.appserver.application.model.json.model.ContentEncryptionSettings;
 import com.contentgrid.appserver.application.model.json.model.ApplicationSchema;
+import com.contentgrid.appserver.application.model.json.model.ApplicationSettings;
 import com.contentgrid.appserver.application.model.json.model.Attribute;
 import com.contentgrid.appserver.application.model.json.model.AttributeConstraint;
 import com.contentgrid.appserver.application.model.json.model.CompositeAttribute;
 import com.contentgrid.appserver.application.model.json.model.ContentAttribute;
+import com.contentgrid.appserver.application.model.json.model.DatabaseSettings;
 import com.contentgrid.appserver.application.model.json.model.Entity;
 import com.contentgrid.appserver.application.model.json.model.ManyToManyRelation;
 import com.contentgrid.appserver.application.model.json.model.OneToManyRelation;
@@ -170,6 +172,9 @@ public class DefaultApplicationSchemaConverter implements ApplicationSchemaConve
         if (json.getContentEncryption() != null) {
             builder.contentEncryption(fromJsonContentEncryption(json.getContentEncryption()));
         }
+        if (json.getDatabase() != null) {
+            builder.database(fromJsonDatabaseSettings(json.getDatabase()));
+        }
         return builder.build();
     }
 
@@ -187,6 +192,13 @@ public class DefaultApplicationSchemaConverter implements ApplicationSchemaConve
                     .forEach(builder::keyWrapperAlgorithm);
         }
         return builder.build();
+    }
+
+    private com.contentgrid.appserver.application.model.settings.database.DatabaseSettings fromJsonDatabaseSettings(
+            DatabaseSettings json) {
+        return com.contentgrid.appserver.application.model.settings.database.DatabaseSettings.builder()
+                .schema(SchemaName.of(json.getSchema()))
+                .build();
     }
 
     private com.contentgrid.appserver.application.model.Entity fromJsonEntity(
@@ -509,6 +521,9 @@ public class DefaultApplicationSchemaConverter implements ApplicationSchemaConve
         applicationSettings.getContentEncryption()
                 .map(this::toJsonContentEncryptionSettings)
                 .ifPresent(json::setContentEncryption);
+        applicationSettings.getDatabase()
+                .map(this::toJsonDatabaseSettings)
+                .ifPresent(json::setDatabase);
         return json;
     }
 
@@ -527,6 +542,12 @@ public class DefaultApplicationSchemaConverter implements ApplicationSchemaConve
         }
         return json;
     }
+     private DatabaseSettings toJsonDatabaseSettings(
+             com.contentgrid.appserver.application.model.settings.database.DatabaseSettings settings) {
+        var json = new DatabaseSettings();
+        json.setSchema(settings.getSchema().getValue());
+        return json;
+     }
 
     private Entity toJsonEntity(com.contentgrid.appserver.application.model.Entity entity) {
         var jsonEntity = new Entity();

--- a/contentgrid-appserver-application-model-json/src/main/java/com/contentgrid/appserver/application/model/json/DefaultApplicationSchemaConverter.java
+++ b/contentgrid-appserver-application-model-json/src/main/java/com/contentgrid/appserver/application/model/json/DefaultApplicationSchemaConverter.java
@@ -196,9 +196,11 @@ public class DefaultApplicationSchemaConverter implements ApplicationSchemaConve
 
     private com.contentgrid.appserver.application.model.settings.database.DatabaseSettings fromJsonDatabaseSettings(
             DatabaseSettings json) {
-        return com.contentgrid.appserver.application.model.settings.database.DatabaseSettings.builder()
-                .schema(SchemaName.of(json.getSchema()))
-                .build();
+        var builder = com.contentgrid.appserver.application.model.settings.database.DatabaseSettings.builder();
+        if (json.getSchema() != null) {
+            builder.schema(SchemaName.of(json.getSchema()));
+        }
+        return builder.build();
     }
 
     private com.contentgrid.appserver.application.model.Entity fromJsonEntity(
@@ -545,7 +547,9 @@ public class DefaultApplicationSchemaConverter implements ApplicationSchemaConve
      private DatabaseSettings toJsonDatabaseSettings(
              com.contentgrid.appserver.application.model.settings.database.DatabaseSettings settings) {
         var json = new DatabaseSettings();
-        json.setSchema(settings.getSchema().getValue());
+        if (settings.getSchema() != null) {
+            json.setSchema(settings.getSchema().getValue());
+        }
         return json;
      }
 

--- a/contentgrid-appserver-application-model-json/src/main/java/com/contentgrid/appserver/application/model/json/model/ApplicationSettings.java
+++ b/contentgrid-appserver-application-model-json/src/main/java/com/contentgrid/appserver/application/model/json/model/ApplicationSettings.java
@@ -10,5 +10,6 @@ import lombok.Setter;
 public class ApplicationSettings {
 
     private ContentEncryptionSettings contentEncryption;
+    private DatabaseSettings database;
 
 }

--- a/contentgrid-appserver-application-model-json/src/main/java/com/contentgrid/appserver/application/model/json/model/DatabaseSettings.java
+++ b/contentgrid-appserver-application-model-json/src/main/java/com/contentgrid/appserver/application/model/json/model/DatabaseSettings.java
@@ -1,0 +1,13 @@
+package com.contentgrid.appserver.application.model.json.model;
+
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.Setter;
+
+@Getter
+@Setter
+public final class DatabaseSettings {
+
+    @NonNull
+    private String schema;
+}

--- a/contentgrid-appserver-application-model-json/src/main/java/com/contentgrid/appserver/application/model/json/model/DatabaseSettings.java
+++ b/contentgrid-appserver-application-model-json/src/main/java/com/contentgrid/appserver/application/model/json/model/DatabaseSettings.java
@@ -1,13 +1,13 @@
 package com.contentgrid.appserver.application.model.json.model;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.Setter;
 
 @Getter
 @Setter
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public final class DatabaseSettings {
 
-    @NonNull
     private String schema;
 }

--- a/contentgrid-appserver-application-model-json/src/main/resources/schemas/application-schema.json
+++ b/contentgrid-appserver-application-model-json/src/main/resources/schemas/application-schema.json
@@ -247,9 +247,6 @@
               "description": "The database schema for this application"
             }
           },
-          "required": [
-            "schema"
-          ],
           "additionalProperties": false
         }
       },

--- a/contentgrid-appserver-application-model-json/src/main/resources/schemas/application-schema.json
+++ b/contentgrid-appserver-application-model-json/src/main/resources/schemas/application-schema.json
@@ -237,6 +237,20 @@
             }
           },
           "additionalProperties": false
+        },
+        "database": {
+          "type": "object",
+          "description": "Database configuration for this application (only database schema for now).",
+          "properties": {
+            "schema": {
+              "type": "string",
+              "description": "The database schema for this application"
+            }
+          },
+          "required": [
+            "schema"
+          ],
+          "additionalProperties": false
         }
       },
       "additionalProperties": false

--- a/contentgrid-appserver-application-model-json/src/test/java/com/contentgrid/appserver/application/model/json/DefaultApplicationSchemaConverterTest.java
+++ b/contentgrid-appserver-application-model-json/src/test/java/com/contentgrid/appserver/application/model/json/DefaultApplicationSchemaConverterTest.java
@@ -196,6 +196,33 @@ class DefaultApplicationSchemaConverterTest {
     }
 
     @Test
+    void testDatabaseSettingsSerialization_noSchema() {
+        var app = Application.builder()
+                .name(ApplicationName.of("test"))
+                .settings(ApplicationSettings.builder()
+                        .database(DatabaseSettings.builder().build())
+                        .build())
+                .build();
+
+        var out = new ByteArrayOutputStream();
+        new DefaultApplicationSchemaConverter().toJson(app, out);
+        var jsonOutput = out.toString(StandardCharsets.UTF_8);
+
+        assertThat(jsonOutput, sameJSONAs("""
+                {
+                    "$schema": "https://contentgrid.cloud/schemas/application-schema.json",
+                    "applicationName": "test",
+                    "version": "1.0.0",
+                    "entities": [],
+                    "relations": [],
+                    "settings": {
+                        "database": {}
+                    }
+                }
+                """));
+    }
+
+    @Test
     void testUnknownFlag() {
         var jsonWithUnknownFlag = """
                 {

--- a/contentgrid-appserver-application-model-json/src/test/java/com/contentgrid/appserver/application/model/json/DefaultApplicationSchemaConverterTest.java
+++ b/contentgrid-appserver-application-model-json/src/test/java/com/contentgrid/appserver/application/model/json/DefaultApplicationSchemaConverterTest.java
@@ -11,6 +11,7 @@ import static uk.co.datumedge.hamcrest.json.SameJSONAs.sameJSONAs;
 import com.contentgrid.appserver.application.model.Application;
 import com.contentgrid.appserver.application.model.Constraint;
 import com.contentgrid.appserver.application.model.settings.ApplicationSettings;
+import com.contentgrid.appserver.application.model.settings.database.DatabaseSettings;
 import com.contentgrid.appserver.application.model.settings.encryption.ContentEncryptionSettings;
 import com.contentgrid.appserver.application.model.settings.encryption.ContentEncryptionEngineAlgorithm;
 import com.contentgrid.appserver.application.model.settings.encryption.ContentEncryptionKeyWrapperAlgorithm;
@@ -29,6 +30,7 @@ import com.contentgrid.appserver.application.model.values.EntityName;
 import com.contentgrid.appserver.application.model.values.LinkName;
 import com.contentgrid.appserver.application.model.values.PathSegmentName;
 import com.contentgrid.appserver.application.model.values.RelationName;
+import com.contentgrid.appserver.application.model.values.SchemaName;
 import com.contentgrid.appserver.application.model.values.TableName;
 import com.contentgrid.appserver.application.model.json.exceptions.InvalidJsonException;
 import com.contentgrid.appserver.application.model.json.exceptions.SchemaValidationException;
@@ -134,6 +136,59 @@ class DefaultApplicationSchemaConverterTest {
                         "contentEncryption": {
                             "encryptionEngineAlgorithms": ["AES256_CTR"],
                             "keyWrapperAlgorithms": ["NONE"]
+                        }
+                    }
+                }
+                """));
+    }
+
+    @Test
+    void testDatabaseSettingsDeserialization() throws Exception {
+        var json = """
+                {
+                    "$schema": "https://contentgrid.cloud/schemas/application-schema.json",
+                    "applicationName": "test",
+                    "version": "1.0.0",
+                    "entities": [],
+                    "relations": [],
+                    "settings": {
+                        "database": {
+                            "schema": "V1"
+                        }
+                    }
+                }
+                """;
+        var app = new DefaultApplicationSchemaConverter().convert(new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8)));
+        var settings = app.getSettings().getDatabase();
+        assertTrue(settings.isPresent());
+        assertEquals(SchemaName.of("V1"), settings.get().getSchema());
+    }
+
+    @Test
+    void testDatabaseSettingsSerialization() {
+        var app = Application.builder()
+                .name(ApplicationName.of("test"))
+                .settings(ApplicationSettings.builder()
+                        .database(DatabaseSettings.builder()
+                                .schema(SchemaName.of("V1"))
+                                .build())
+                        .build())
+                .build();
+
+        var out = new ByteArrayOutputStream();
+        new DefaultApplicationSchemaConverter().toJson(app, out);
+        var jsonOutput = out.toString(StandardCharsets.UTF_8);
+
+        assertThat(jsonOutput, sameJSONAs("""
+                {
+                    "$schema": "https://contentgrid.cloud/schemas/application-schema.json",
+                    "applicationName": "test",
+                    "version": "1.0.0",
+                    "entities": [],
+                    "relations": [],
+                    "settings": {
+                        "database": {
+                            "schema": "V1"
                         }
                     }
                 }

--- a/contentgrid-appserver-application-model/src/main/java/com/contentgrid/appserver/application/model/settings/ApplicationSettings.java
+++ b/contentgrid-appserver-application-model/src/main/java/com/contentgrid/appserver/application/model/settings/ApplicationSettings.java
@@ -1,5 +1,6 @@
 package com.contentgrid.appserver.application.model.settings;
 
+import com.contentgrid.appserver.application.model.settings.database.DatabaseSettings;
 import com.contentgrid.appserver.application.model.settings.encryption.ContentEncryptionSettings;
 import java.util.Optional;
 import lombok.Builder;
@@ -10,9 +11,14 @@ import lombok.Value;
 public class ApplicationSettings {
 
     ContentEncryptionSettings contentEncryption;
+    DatabaseSettings database;
 
     public Optional<ContentEncryptionSettings> getContentEncryption() {
         return Optional.ofNullable(contentEncryption);
+    }
+
+    public Optional<DatabaseSettings> getDatabase() {
+        return Optional.ofNullable(database);
     }
 
 }

--- a/contentgrid-appserver-application-model/src/main/java/com/contentgrid/appserver/application/model/settings/database/DatabaseSettings.java
+++ b/contentgrid-appserver-application-model/src/main/java/com/contentgrid/appserver/application/model/settings/database/DatabaseSettings.java
@@ -2,13 +2,11 @@ package com.contentgrid.appserver.application.model.settings.database;
 
 import com.contentgrid.appserver.application.model.values.SchemaName;
 import lombok.Builder;
-import lombok.NonNull;
 import lombok.Value;
 
 @Builder
 @Value
 public class DatabaseSettings {
 
-    @NonNull
     SchemaName schema;
 }

--- a/contentgrid-appserver-application-model/src/main/java/com/contentgrid/appserver/application/model/settings/database/DatabaseSettings.java
+++ b/contentgrid-appserver-application-model/src/main/java/com/contentgrid/appserver/application/model/settings/database/DatabaseSettings.java
@@ -1,0 +1,14 @@
+package com.contentgrid.appserver.application.model.settings.database;
+
+import com.contentgrid.appserver.application.model.values.SchemaName;
+import lombok.Builder;
+import lombok.NonNull;
+import lombok.Value;
+
+@Builder
+@Value
+public class DatabaseSettings {
+
+    @NonNull
+    SchemaName schema;
+}

--- a/contentgrid-appserver-application-model/src/main/java/com/contentgrid/appserver/application/model/values/SchemaName.java
+++ b/contentgrid-appserver-application-model/src/main/java/com/contentgrid/appserver/application/model/values/SchemaName.java
@@ -1,0 +1,18 @@
+package com.contentgrid.appserver.application.model.values;
+
+import lombok.NonNull;
+import lombok.Value;
+
+@Value(staticConstructor = "of")
+public class SchemaName {
+
+    @NonNull
+    String value;
+
+    @Override
+    public String toString() {
+        return getValue();
+    }
+
+    public static final SchemaName PUBLIC = SchemaName.of("public");
+}

--- a/contentgrid-appserver-application-model/src/test/java/com/contentgrid/appserver/application/model/ApplicationTest.java
+++ b/contentgrid-appserver-application-model/src/test/java/com/contentgrid/appserver/application/model/ApplicationTest.java
@@ -34,6 +34,7 @@ import com.contentgrid.appserver.application.model.searchfilters.AttributeSearch
 import com.contentgrid.appserver.application.model.searchfilters.AttributeSearchFilter.Operation;
 import com.contentgrid.appserver.application.model.searchfilters.flags.SyntheticSearchFilterFlag;
 import com.contentgrid.appserver.application.model.settings.ApplicationSettings;
+import com.contentgrid.appserver.application.model.settings.database.DatabaseSettings;
 import com.contentgrid.appserver.application.model.settings.encryption.ContentEncryptionEngineAlgorithm;
 import com.contentgrid.appserver.application.model.settings.encryption.ContentEncryptionKeyWrapperAlgorithm;
 import com.contentgrid.appserver.application.model.settings.encryption.ContentEncryptionSettings;
@@ -46,6 +47,7 @@ import com.contentgrid.appserver.application.model.values.LinkName;
 import com.contentgrid.appserver.application.model.values.PathSegmentName;
 import com.contentgrid.appserver.application.model.values.PropertyPath;
 import com.contentgrid.appserver.application.model.values.RelationName;
+import com.contentgrid.appserver.application.model.values.SchemaName;
 import com.contentgrid.appserver.application.model.values.TableName;
 import java.util.List;
 import java.util.function.Supplier;
@@ -642,6 +644,24 @@ class ApplicationTest {
                 settings.getEncryptionEngineAlgorithms().getFirst());
         assertEquals(ContentEncryptionEngineAlgorithm.AES128_CTR,
                 settings.getEncryptionEngineAlgorithms().getLast());
+    }
+
+    @Test
+    void application_databaseSchema() {
+        var application = Application.builder()
+                .name(ApplicationName.of("databaseSchemaApplication"))
+                .entity(INVOICE)
+                .entity(CUSTOMER)
+                .relation(MANY_TO_ONE)
+                .settings(ApplicationSettings.builder()
+                        .database(DatabaseSettings.builder()
+                                .schema(SchemaName.of("V1"))
+                                .build())
+                        .build())
+                .build();
+        assertTrue(application.getSettings().getDatabase().isPresent());
+        var settings = application.getSettings().getDatabase().orElseThrow();
+        assertEquals(SchemaName.of("V1"), settings.getSchema());
     }
 
     /**

--- a/contentgrid-appserver-autoconfigure/src/main/java/com/contentgrid/appserver/autoconfigure/query/engine/JOOQQueryEngineAutoConfiguration.java
+++ b/contentgrid-appserver-autoconfigure/src/main/java/com/contentgrid/appserver/autoconfigure/query/engine/JOOQQueryEngineAutoConfiguration.java
@@ -27,6 +27,8 @@ import org.springframework.boot.jooq.autoconfigure.ExceptionTranslatorExecuteLis
 import org.springframework.boot.jooq.autoconfigure.JooqAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Primary;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 import org.springframework.transaction.PlatformTransactionManager;
 
 @AutoConfiguration(after = {ApplicationResolverAutoConfiguration.class}, before = JooqAutoConfiguration.class)
@@ -58,6 +60,7 @@ public class JOOQQueryEngineAutoConfiguration {
     }
 
     @Bean
+    @Order(Ordered.HIGHEST_PRECEDENCE)
     TableCreator jooqTableCreator(DSLContextResolver dslContextResolver) {
         return new JOOQTableCreator(dslContextResolver);
     }

--- a/contentgrid-appserver-query-engine-impl-jooq/src/main/java/com/contentgrid/appserver/query/engine/jooq/JOOQTableCreator.java
+++ b/contentgrid-appserver-query-engine-impl-jooq/src/main/java/com/contentgrid/appserver/query/engine/jooq/JOOQTableCreator.java
@@ -6,6 +6,7 @@ import com.contentgrid.appserver.application.model.Entity;
 import com.contentgrid.appserver.application.model.attributes.Attribute;
 import com.contentgrid.appserver.application.model.attributes.CompositeAttribute;
 import com.contentgrid.appserver.application.model.attributes.SimpleAttribute;
+import com.contentgrid.appserver.application.model.values.SchemaName;
 import com.contentgrid.appserver.query.engine.api.TableCreator;
 import com.contentgrid.appserver.query.engine.jooq.resolver.DSLContextResolver;
 import com.contentgrid.appserver.query.engine.jooq.strategy.JOOQRelationStrategyFactory;
@@ -25,6 +26,9 @@ public class JOOQTableCreator implements TableCreator {
     @Override
     public void createTables(Application application) {
         var dslContext = resolver.resolve(application);
+        // Create schema first
+        createSchema(dslContext, application);
+
         for (var entity : application.getEntities()) {
             createTableForEntity(dslContext, entity);
         }
@@ -35,6 +39,24 @@ public class JOOQTableCreator implements TableCreator {
         }
         // Create extensions schema and functions
         createCGPrefixSearchNormalize(dslContext);
+    }
+
+    private void createSchema(DSLContext dslContext, Application application) {
+        application.getSettings().getDatabase().ifPresent(settings -> {
+            if (!SchemaName.PUBLIC.equals(settings.getSchema())) {
+                var schema = DSL.schema(DSL.name(settings.getSchema().getValue()));
+                dslContext.createSchemaIfNotExists(schema).execute();
+            }
+        });
+    }
+
+    private void dropSchema(DSLContext dslContext, Application application) {
+        application.getSettings().getDatabase().ifPresent(settings -> {
+            if (!SchemaName.PUBLIC.equals(settings.getSchema())) {
+                var schema = DSL.schema(DSL.name(settings.getSchema().getValue()));
+                dslContext.dropSchemaIfExists(schema).execute();
+            }
+        });
     }
 
     private void createTableForEntity(DSLContext dslContext, Entity entity) {
@@ -83,6 +105,7 @@ public class JOOQTableCreator implements TableCreator {
 
         // Drop extensions schema and functions
         dropCGPrefixSearchNormalize(dslContext);
+        dropSchema(dslContext, application);
     }
 
     @Allow.PlainSQL

--- a/contentgrid-appserver-query-engine-impl-jooq/src/main/java/com/contentgrid/appserver/query/engine/jooq/JOOQTableCreator.java
+++ b/contentgrid-appserver-query-engine-impl-jooq/src/main/java/com/contentgrid/appserver/query/engine/jooq/JOOQTableCreator.java
@@ -43,7 +43,7 @@ public class JOOQTableCreator implements TableCreator {
 
     private void createSchema(DSLContext dslContext, Application application) {
         application.getSettings().getDatabase().ifPresent(settings -> {
-            if (!SchemaName.PUBLIC.equals(settings.getSchema())) {
+            if (settings.getSchema() != null && !SchemaName.PUBLIC.equals(settings.getSchema())) {
                 var schema = DSL.schema(DSL.name(settings.getSchema().getValue()));
                 dslContext.createSchemaIfNotExists(schema).execute();
             }
@@ -52,7 +52,7 @@ public class JOOQTableCreator implements TableCreator {
 
     private void dropSchema(DSLContext dslContext, Application application) {
         application.getSettings().getDatabase().ifPresent(settings -> {
-            if (!SchemaName.PUBLIC.equals(settings.getSchema())) {
+            if (settings.getSchema() != null && !SchemaName.PUBLIC.equals(settings.getSchema())) {
                 var schema = DSL.schema(DSL.name(settings.getSchema().getValue()));
                 dslContext.dropSchemaIfExists(schema).execute();
             }

--- a/contentgrid-appserver-query-engine-impl-jooq/src/main/java/com/contentgrid/appserver/query/engine/jooq/resolver/AutowiredDSLContextResolver.java
+++ b/contentgrid-appserver-query-engine-impl-jooq/src/main/java/com/contentgrid/appserver/query/engine/jooq/resolver/AutowiredDSLContextResolver.java
@@ -30,6 +30,9 @@ public class AutowiredDSLContextResolver implements DSLContextResolver {
     }
 
     private Settings configureSchema(Settings settings, SchemaName schemaName) {
+        if (schemaName == null) {
+            return settings;
+        }
         var renderMapping = settings.getRenderMapping() == null ? new RenderMapping() : settings.getRenderMapping();
         var schemata = new ArrayList<>(renderMapping.getSchemata());
 

--- a/contentgrid-appserver-query-engine-impl-jooq/src/main/java/com/contentgrid/appserver/query/engine/jooq/resolver/AutowiredDSLContextResolver.java
+++ b/contentgrid-appserver-query-engine-impl-jooq/src/main/java/com/contentgrid/appserver/query/engine/jooq/resolver/AutowiredDSLContextResolver.java
@@ -1,8 +1,14 @@
 package com.contentgrid.appserver.query.engine.jooq.resolver;
 
 import com.contentgrid.appserver.application.model.Application;
+import com.contentgrid.appserver.application.model.values.SchemaName;
+import java.util.ArrayList;
 import lombok.RequiredArgsConstructor;
 import org.jooq.DSLContext;
+import org.jooq.conf.MappedSchema;
+import org.jooq.conf.RenderMapping;
+import org.jooq.conf.Settings;
+import org.jooq.impl.DSL;
 
 @RequiredArgsConstructor
 public class AutowiredDSLContextResolver implements DSLContextResolver {
@@ -11,6 +17,25 @@ public class AutowiredDSLContextResolver implements DSLContextResolver {
 
     @Override
     public DSLContext resolve(Application application) {
-        return dslContext;
+        var maybeDatabaseSettings = application.getSettings().getDatabase();
+        if (maybeDatabaseSettings.isEmpty()) {
+            return dslContext;
+        }
+        var databaseSettings = maybeDatabaseSettings.get();
+
+        var derivedConfig = dslContext.configuration()
+                .deriveSettings(settings -> configureSchema(settings, databaseSettings.getSchema()));
+
+        return DSL.using(derivedConfig);
+    }
+
+    private Settings configureSchema(Settings settings, SchemaName schemaName) {
+        var renderMapping = settings.getRenderMapping() == null ? new RenderMapping() : settings.getRenderMapping();
+        var schemata = new ArrayList<>(renderMapping.getSchemata());
+
+        // Replace default/empty schema with the configured schema in generated sql
+        schemata.add(new MappedSchema().withInput("").withOutput(schemaName.getValue()));
+
+        return settings.withRenderMapping(renderMapping.withSchemata(schemata));
     }
 }

--- a/contentgrid-appserver-query-engine-impl-jooq/src/test/java/com/contentgrid/appserver/query/engine/jooq/JOOQTableCreatorTest.java
+++ b/contentgrid-appserver-query-engine-impl-jooq/src/test/java/com/contentgrid/appserver/query/engine/jooq/JOOQTableCreatorTest.java
@@ -1,6 +1,7 @@
 package com.contentgrid.appserver.query.engine.jooq;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -28,6 +29,8 @@ import com.contentgrid.appserver.application.model.relations.flags.HiddenEndpoin
 import com.contentgrid.appserver.application.model.relations.flags.RequiredEndpointFlag;
 import com.contentgrid.appserver.application.model.searchfilters.AttributeSearchFilter;
 import com.contentgrid.appserver.application.model.searchfilters.AttributeSearchFilter.Operation;
+import com.contentgrid.appserver.application.model.settings.ApplicationSettings;
+import com.contentgrid.appserver.application.model.settings.database.DatabaseSettings;
 import com.contentgrid.appserver.application.model.values.ApplicationName;
 import com.contentgrid.appserver.application.model.values.AttributeName;
 import com.contentgrid.appserver.application.model.values.ColumnName;
@@ -36,6 +39,7 @@ import com.contentgrid.appserver.application.model.values.FilterName;
 import com.contentgrid.appserver.application.model.values.LinkName;
 import com.contentgrid.appserver.application.model.values.PathSegmentName;
 import com.contentgrid.appserver.application.model.values.RelationName;
+import com.contentgrid.appserver.application.model.values.SchemaName;
 import com.contentgrid.appserver.application.model.values.TableName;
 import com.contentgrid.appserver.query.engine.api.TableCreator;
 import com.contentgrid.appserver.query.engine.jooq.test.JooqTest;
@@ -257,6 +261,22 @@ class JOOQTableCreatorTest {
     @Autowired
     private JdbcTemplate jdbcTemplate;
 
+    private List<String> getSchemas() {
+        return jdbcTemplate.execute((Connection con) -> {
+            List<String> result = new ArrayList<>();
+            DatabaseMetaData metaData = con.getMetaData();
+
+            log.debug("Querying metadata for schemas");
+
+            try (ResultSet columns = metaData.getSchemas()) {
+                while (columns.next()) {
+                    String schema = columns.getString("TABLE_SCHEM");
+                    result.add(schema);
+                }
+            }
+            return result; // Return the list from the callback
+        });
+    }
 
     private List<String> getTables(String dbSchema) {
         // Get all tables for the given schema
@@ -264,9 +284,9 @@ class JOOQTableCreatorTest {
             List<String> result = new ArrayList<>();
             DatabaseMetaData metaData = con.getMetaData();
 
-            log.debug("Querying metadata for tables in schema: %s%n", dbSchema);
+            log.debug("Querying metadata for tables in schema: {}", dbSchema);
 
-            try (ResultSet columns = metaData.getTables(null, dbSchema, null, null)) {
+            try (ResultSet columns = metaData.getTables(null, dbSchema, null, new String[]{"TABLE"})) {
                 while (columns.next()) {
                     String table = columns.getString("TABLE_NAME");
                     result.add(table);
@@ -284,7 +304,7 @@ class JOOQTableCreatorTest {
             Map<String, String> columnData = new HashMap<>();
             DatabaseMetaData metaData = con.getMetaData();
 
-            log.debug("Querying metadata for columns in table: %s.%s%n", dbSchema, tableName);
+            log.debug("Querying metadata for columns in table: {}.{}", dbSchema, tableName);
 
             try (ResultSet columns = metaData.getColumns(null, dbSchema, tableName, null)) {
                 boolean foundColumn = false;
@@ -294,7 +314,7 @@ class JOOQTableCreatorTest {
                     String typeName = columns.getString("TYPE_NAME");
                     int dataType = columns.getInt("DATA_TYPE");
 
-                    log.debug("Found column: %s, DB Type: %s, SQL Type: %d%n",
+                    log.debug("Found column: {}, DB Type: {}, SQL Type: {}",
                             columnName, typeName, dataType);
 
                     // Store details (lowercase key for consistent comparison)
@@ -315,7 +335,7 @@ class JOOQTableCreatorTest {
             Map<String, String> foreignKeyData = new HashMap<>();
             DatabaseMetaData metaData = con.getMetaData();
 
-            log.debug("Querying metadata for foreign keys in table: %s.%s%n", dbSchema, tableName);
+            log.debug("Querying metadata for foreign keys in table: {}.{}", dbSchema, tableName);
 
             try (ResultSet columns = metaData.getImportedKeys(null, dbSchema, tableName)) {
                 while (columns.next()) {
@@ -498,6 +518,55 @@ class JOOQTableCreatorTest {
         // drop tables
         tableCreator.dropTables(application);
         assertTrue(getTables("public").isEmpty());
+    }
+
+    @Test
+    void applicationWithSchema() {
+        var application = Application.builder()
+                .name(ApplicationName.of("test-schema-application"))
+                .settings(ApplicationSettings.builder()
+                        .database(DatabaseSettings.builder()
+                                .schema(SchemaName.of("test"))
+                                .build())
+                        .build())
+                .entity(PERSON)
+                .build();
+
+        // create tables
+        tableCreator.createTables(application);
+
+        assertTrue(getTables("public").isEmpty());
+        var tables = getTables("test");
+        assertEquals(List.of("person"), tables);
+
+        // drop tables
+        tableCreator.dropTables(application);
+        assertTrue(getTables("test").isEmpty());
+        assertFalse(getSchemas().contains("test"));
+    }
+
+    @Test
+    void applicationWithPublicSchema() {
+        var application = Application.builder()
+                .name(ApplicationName.of("public-schema-application"))
+                .settings(ApplicationSettings.builder()
+                        .database(DatabaseSettings.builder()
+                                .schema(SchemaName.PUBLIC)
+                                .build())
+                        .build())
+                .entity(PERSON)
+                .build();
+
+        // create tables
+        tableCreator.createTables(application);
+
+        var tables = getTables("public");
+        assertEquals(List.of("person"), tables);
+
+        // drop tables
+        tableCreator.dropTables(application);
+        assertTrue(getTables("public").isEmpty());
+        assertTrue(getSchemas().contains("public")); // public is not dropped
     }
 
     @Test

--- a/contentgrid-appserver-query-engine-impl-jooq/src/test/java/com/contentgrid/appserver/query/engine/jooq/JOOQTableCreatorTest.java
+++ b/contentgrid-appserver-query-engine-impl-jooq/src/test/java/com/contentgrid/appserver/query/engine/jooq/JOOQTableCreatorTest.java
@@ -546,6 +546,28 @@ class JOOQTableCreatorTest {
     }
 
     @Test
+    void applicationWithNoSchema() {
+        var application = Application.builder()
+                .name(ApplicationName.of("no-schema-application"))
+                .settings(ApplicationSettings.builder()
+                        .database(DatabaseSettings.builder().build())
+                        .build())
+                .entity(PERSON)
+                .build();
+
+        // create tables
+        tableCreator.createTables(application);
+
+        var tables = getTables("public");
+        assertEquals(List.of("person"), tables);
+
+        // drop tables
+        tableCreator.dropTables(application);
+        assertTrue(getTables("public").isEmpty());
+        assertTrue(getSchemas().contains("public")); // public is not dropped
+    }
+
+    @Test
     void applicationWithPublicSchema() {
         var application = Application.builder()
                 .name(ApplicationName.of("public-schema-application"))


### PR DESCRIPTION
update `AutowiredDSLContextResolver`:
- configures default database schema used in generated sql queries. Configuring `spring.datasource.hikari.schema` will not have any effect since schema is specified in all sql queries.
- Doesn't configure anything if `DatabaseSettings` absent, so you can still use `spring.datasource.hikari.schema`

update `JOOQTableCreator`:
- create schema first in `createTables` if `DatabaseSettings` is present and schema is not equal to `public`.
- drop schema last in `dropTables` if `DatabaseSettings` is present and schema is not equal to `public`.
- bean has `@Order(Ordered.HIGHEST_PRECEDENCE)` because schema needs to exist when `DataEncryptionKeyTableCreator` creates its table (also uses a `DSLContextResolver` which sets the schema).
- `JOOQTableCreatorTest` fixes: only return tables in `getTables` (and exclude indexes, views, system tables, ...) and correct log formatting.