### PR TITLE
ACC-3056 Build multi-arch images via ext.docker-multiarch plugin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,10 +39,13 @@ jobs:
           ORG_GRADLE_PROJECT_mavenCentralPublishUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPublishPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
         run: ./gradlew publish
+      - name: Set up QEMU for cross-architecture image builds
+        if: ${{ github.ref == 'refs/heads/main' || startswith(github.ref, 'refs/tags/') }}
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
       - name: Publish to ghcr.io
         if: ${{ github.ref == 'refs/heads/main' || startswith(github.ref, 'refs/tags/') }}
         env:
           ORG_GRADLE_PROJECT_DOCKER_PUBLISH_REGISTRY_URL: ghcr.io
           ORG_GRADLE_PROJECT_DOCKER_PUBLISH_REGISTRY_USERNAME: ${{ github.actor }}
           ORG_GRADLE_PROJECT_DOCKER_PUBLISH_REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-        run: ./gradlew bootBuildImage --publishImage
+        run: ./gradlew bootBuildLinuxAmd64Image --publishImage bootBuildLinuxArm64Image --publishImage

--- a/settings.gradle
+++ b/settings.gradle
@@ -7,7 +7,7 @@ pluginManagement {
 
 plugins {
     id 'org.ajoberstar.reckon.settings' version '2.0.0'
-    id 'eu.xenit.enterprise-conventions.oss' version '0.7.0'
+    id 'eu.xenit.enterprise-conventions.oss' version '0.8.0'
 }
 
 reckon {


### PR DESCRIPTION
Enables multi-arch (amd64 + arm64) image publishing via the `ext.docker-multiarch` conventions plugin (enterprise-conventions 0.8.0), which registers the `bootBuildLinuxAmd64Image`/`bootBuildLinuxArm64Image` tasks derived from `bootBuildImage`.

- `settings.gradle`: bump the conventions plugin 0.7.0 → 0.8.0.
- `ci.yml`: add the QEMU setup step and publish both architectures.

Part of the ACC-3056 rollout; same pattern as contentgrid-rendition-service (reference).