### PR TITLE
fix: schema-qualified alias breaks ABAC findById (HTTP 500) [ACC-3112]

### DIFF
--- a/contentgrid-appserver-query-engine-impl-jooq/src/main/java/com/contentgrid/appserver/query/engine/jooq/JOOQQueryEngine.java
+++ b/contentgrid-appserver-query-engine-impl-jooq/src/main/java/com/contentgrid/appserver/query/engine/jooq/JOOQQueryEngine.java
@@ -119,7 +119,7 @@ public class JOOQQueryEngine implements QueryEngine {
         var dslContext = resolver.resolve(application);
         var context = new JOOQContext(application, entity);
         var alias = context.getRootAlias();
-        var table = JOOQUtils.resolveTable(entity, alias);
+        var table = JOOQUtils.resolveTable(application, entity, alias);
         var orderBy = sortData != null
                 ? sortData.getSortedFields().stream().map(field -> convert(entity, field)).toList()
                 : List.<OrderField<?>>of();
@@ -170,7 +170,7 @@ public class JOOQQueryEngine implements QueryEngine {
         var entity = application.getRequiredEntityByName(entityRequest.getEntityName());
         var context = new JOOQContext(application, entity);
         var alias = context.getRootAlias();
-        var table = JOOQUtils.resolveTable(entity, alias);
+        var table = JOOQUtils.resolveTable(application, entity, alias);
         var primaryKey = JOOQUtils.resolvePrimaryKey(alias, entity);
 
         var fields = new ArrayList<>(Arrays.asList(JOOQUtils.resolveAttributeFields(entity)));
@@ -264,7 +264,7 @@ public class JOOQQueryEngine implements QueryEngine {
         EntityData insertedData;
         try {
             var insertedRecord = DslContextUtils.executeInSavepoint(dslContext, () -> dslContext
-                    .insertInto(JOOQUtils.resolveTable(entity))
+                    .insertInto(JOOQUtils.resolveTable(application, entity))
                     .set(createFields)
                     .returning(JOOQUtils.resolveAttributeFields(entity))
                     .fetchSingleMap());
@@ -341,7 +341,7 @@ public class JOOQQueryEngine implements QueryEngine {
             @NonNull UpdateEventConsumer updateEventConsumer) throws QueryEngineException {
         var dslContext = resolver.resolve(application);
         var entity = application.getRequiredEntityByName(data.getName());
-        var table = JOOQUtils.resolveTable(entity);
+        var table = JOOQUtils.resolveTable(application, entity);
         var primaryKey = JOOQUtils.resolvePrimaryKey(entity);
         var id = data.getId();
 
@@ -524,7 +524,7 @@ public class JOOQQueryEngine implements QueryEngine {
                                             versionField,
                                             DSL.val(fieldName).as(identificationField)
                                     )
-                                    .from(JOOQUtils.resolveTable(entity))
+                                    .from(JOOQUtils.resolveTable(application, entity))
                                     .where(field.equal((Field)value))
                                     .and(primaryKeyField.notEqual(entityIdentity.getEntityId().getValue()))
                     );
@@ -604,7 +604,7 @@ public class JOOQQueryEngine implements QueryEngine {
                     var value = DSL.val(entityData.get(entry.getKey()), field.getDataType());
 
                     var targetEntity = application.getRelationTargetEntity(entry.getValue());
-                    var targetEntityTable = JOOQUtils.resolveTable(targetEntity);
+                    var targetEntityTable = JOOQUtils.resolveTable(application, targetEntity);
                     var targetEntityPk = JOOQUtils.resolvePrimaryKey(targetEntity);
 
                     return DSL.select(
@@ -657,7 +657,7 @@ public class JOOQQueryEngine implements QueryEngine {
             throws QueryEngineException {
         var dslContext = resolver.resolve(application);
         var entity = application.getRequiredEntityByName(entityRequest.getEntityName());
-        var table = JOOQUtils.resolveTable(entity);
+        var table = JOOQUtils.resolveTable(application, entity);
         var primaryKey = JOOQUtils.resolvePrimaryKey(entity);
 
         assertPermission(application, entityRequest, permitDeletePredicate);
@@ -907,7 +907,7 @@ public class JOOQQueryEngine implements QueryEngine {
         var dslContext = resolver.resolve(application);
         var context = new JOOQContext(application, entity);
         var alias = context.getRootAlias();
-        var table = JOOQUtils.resolveTable(entity, alias);
+        var table = JOOQUtils.resolveTable(application, entity, alias);
 
         var condition = RESOLVER.resolveExpression(expression, context);
         return countStrategy.count(dslContext, DSL.selectFrom(table).where(condition));

--- a/contentgrid-appserver-query-engine-impl-jooq/src/main/java/com/contentgrid/appserver/query/engine/jooq/JOOQTableCreator.java
+++ b/contentgrid-appserver-query-engine-impl-jooq/src/main/java/com/contentgrid/appserver/query/engine/jooq/JOOQTableCreator.java
@@ -30,7 +30,7 @@ public class JOOQTableCreator implements TableCreator {
         createSchema(dslContext, application);
 
         for (var entity : application.getEntities()) {
-            createTableForEntity(dslContext, entity);
+            createTableForEntity(dslContext, application, entity);
         }
         // Create relations after tables are created, so that each table referenced in the foreign key constraint exists
         for (var relation : application.getRelations()) {
@@ -59,8 +59,8 @@ public class JOOQTableCreator implements TableCreator {
         });
     }
 
-    private void createTableForEntity(DSLContext dslContext, Entity entity) {
-        var step = dslContext.createTableIfNotExists(entity.getTable().getValue())
+    private void createTableForEntity(DSLContext dslContext, Application application, Entity entity) {
+        var step = dslContext.createTableIfNotExists(JOOQUtils.resolveTable(application, entity))
                 .column(JOOQUtils.resolvePrimaryKey(entity))
                 .primaryKey(entity.getPrimaryKey().getColumn().getValue());
         for (var attribute : entity.getAttributes()) {
@@ -99,7 +99,7 @@ public class JOOQTableCreator implements TableCreator {
 
         // Drop entity tables after relations are dropped
         for (var entity : application.getEntities()) {
-            var table = JOOQUtils.resolveTable(entity);
+            var table = JOOQUtils.resolveTable(application, entity);
             dslContext.dropTableIfExists(table).execute();
         }
 

--- a/contentgrid-appserver-query-engine-impl-jooq/src/main/java/com/contentgrid/appserver/query/engine/jooq/JOOQUtils.java
+++ b/contentgrid-appserver-query-engine-impl-jooq/src/main/java/com/contentgrid/appserver/query/engine/jooq/JOOQUtils.java
@@ -7,7 +7,9 @@ import com.contentgrid.appserver.application.model.attributes.CompositeAttribute
 import com.contentgrid.appserver.application.model.attributes.SimpleAttribute;
 import com.contentgrid.appserver.application.model.attributes.flags.ETagFlag;
 import com.contentgrid.appserver.application.model.relations.Relation;
+import com.contentgrid.appserver.application.model.settings.database.DatabaseSettings;
 import com.contentgrid.appserver.application.model.values.ColumnName;
+import com.contentgrid.appserver.application.model.values.SchemaName;
 import com.contentgrid.appserver.application.model.values.TableName;
 import com.contentgrid.appserver.query.engine.jooq.strategy.HasSourceTableColumnRef;
 import com.contentgrid.appserver.query.engine.jooq.strategy.JOOQRelationStrategyFactory;
@@ -21,6 +23,7 @@ import org.jooq.Allow;
 import org.jooq.Condition;
 import org.jooq.DataType;
 import org.jooq.Field;
+import org.jooq.Name;
 import org.jooq.Table;
 import org.jooq.impl.DSL;
 import org.jooq.impl.SQLDataType;
@@ -42,6 +45,42 @@ public class JOOQUtils {
 
     public static Table<?> resolveTable(TableName tableName, TableName alias) {
         return DSL.table(DSL.name(tableName.getValue())).as(alias.getValue());
+    }
+
+    /**
+     * Resolve a table reference, schema-qualifying it with the application's configured database schema
+     * (see {@link DatabaseSettings#getSchema()}) when it is a non-{@link SchemaName#PUBLIC} schema.
+     * <p>
+     * Unlike a global jOOQ {@code RenderMapping} (which also qualifies unbound, correlated alias.field
+     * references and produces invalid SQL such as {@code "schema"."alias"."column"}), schema-qualifying
+     * only the table keeps {@code DSL.field(DSL.name(alias, column))} references unqualified, which is
+     * required for correlated subqueries (e.g. the {@code _allow_read} EXISTS built by
+     * {@code JOOQSymbolicReferenceResolver}).
+     */
+    public static Table<?> resolveTable(Application application, Entity entity) {
+        return resolveTable(application, entity.getTable());
+    }
+
+    public static Table<?> resolveTable(Application application, TableName tableName) {
+        return DSL.table(resolveTableName(application, tableName));
+    }
+
+    public static Table<?> resolveTable(Application application, Entity entity, TableName alias) {
+        return resolveTable(application, entity.getTable(), alias);
+    }
+
+    public static Table<?> resolveTable(Application application, TableName tableName, TableName alias) {
+        return DSL.table(resolveTableName(application, tableName)).as(alias.getValue());
+    }
+
+    private static Name resolveTableName(Application application, TableName tableName) {
+        var schema = application.getSettings().getDatabase()
+                .map(DatabaseSettings::getSchema)
+                .filter(schemaName -> !SchemaName.PUBLIC.equals(schemaName));
+        if (schema.isPresent()) {
+            return DSL.name(schema.get().getValue(), tableName.getValue());
+        }
+        return DSL.name(tableName.getValue());
     }
 
     public static Field<?> resolveField(TableName alias, SimpleAttribute attribute) {

--- a/contentgrid-appserver-query-engine-impl-jooq/src/main/java/com/contentgrid/appserver/query/engine/jooq/resolver/AutowiredDSLContextResolver.java
+++ b/contentgrid-appserver-query-engine-impl-jooq/src/main/java/com/contentgrid/appserver/query/engine/jooq/resolver/AutowiredDSLContextResolver.java
@@ -1,15 +1,20 @@
 package com.contentgrid.appserver.query.engine.jooq.resolver;
 
 import com.contentgrid.appserver.application.model.Application;
-import com.contentgrid.appserver.application.model.values.SchemaName;
-import java.util.ArrayList;
 import lombok.RequiredArgsConstructor;
 import org.jooq.DSLContext;
-import org.jooq.conf.MappedSchema;
-import org.jooq.conf.RenderMapping;
-import org.jooq.conf.Settings;
-import org.jooq.impl.DSL;
 
+/**
+ * Resolves the jOOQ {@link DSLContext} to use for an {@link Application}.
+ * <p>
+ * The database schema configured via {@code ApplicationSettings.database.schema} is applied to generated
+ * SQL by explicitly schema-qualifying table references in {@code JOOQUtils.resolveTable(Application, ...)},
+ * <em>not</em> through a global jOOQ {@code RenderMapping}. A {@code RenderMapping} that maps the default
+ * schema also qualifies unbound, correlated alias.field references (e.g. inside the {@code _allow_read}
+ * {@code EXISTS} subquery built by {@code JOOQSymbolicReferenceResolver}), producing invalid SQL such as
+ * {@code "schema"."alias"."column"} which PostgreSQL rejects with
+ * {@code "invalid reference to FROM-clause entry for table ..."}.
+ */
 @RequiredArgsConstructor
 public class AutowiredDSLContextResolver implements DSLContextResolver {
 
@@ -17,28 +22,6 @@ public class AutowiredDSLContextResolver implements DSLContextResolver {
 
     @Override
     public DSLContext resolve(Application application) {
-        var maybeDatabaseSettings = application.getSettings().getDatabase();
-        if (maybeDatabaseSettings.isEmpty()) {
-            return dslContext;
-        }
-        var databaseSettings = maybeDatabaseSettings.get();
-
-        var derivedConfig = dslContext.configuration()
-                .deriveSettings(settings -> configureSchema(settings, databaseSettings.getSchema()));
-
-        return DSL.using(derivedConfig);
-    }
-
-    private Settings configureSchema(Settings settings, SchemaName schemaName) {
-        if (schemaName == null) {
-            return settings;
-        }
-        var renderMapping = settings.getRenderMapping() == null ? new RenderMapping() : settings.getRenderMapping();
-        var schemata = new ArrayList<>(renderMapping.getSchemata());
-
-        // Replace default/empty schema with the configured schema in generated sql
-        schemata.add(new MappedSchema().withInput("").withOutput(schemaName.getValue()));
-
-        return settings.withRenderMapping(renderMapping.withSchemata(schemata));
+        return dslContext;
     }
 }

--- a/contentgrid-appserver-query-engine-impl-jooq/src/main/java/com/contentgrid/appserver/query/engine/jooq/strategy/JOOQManyToManyRelationStrategy.java
+++ b/contentgrid-appserver-query-engine-impl-jooq/src/main/java/com/contentgrid/appserver/query/engine/jooq/strategy/JOOQManyToManyRelationStrategy.java
@@ -25,7 +25,7 @@ final class JOOQManyToManyRelationStrategy extends JOOQXToManyRelationStrategy<M
 
     @Override
     public Table<?> getTable(Application application, ManyToManyRelation relation) {
-        return JOOQUtils.resolveTable(relation.getJoinTable());
+        return JOOQUtils.resolveTable(application, relation.getJoinTable());
     }
 
     @Override
@@ -45,8 +45,8 @@ final class JOOQManyToManyRelationStrategy extends JOOQXToManyRelationStrategy<M
         var joinTable = getTable(application, relation);
         var sourceRef = getSourceRef(application, relation);
         var targetRef = getTargetRef(application, relation);
-        var sourceTable = JOOQUtils.resolveTable(application.getRelationSourceEntity(relation));
-        var targetTable = JOOQUtils.resolveTable(application.getRelationTargetEntity(relation));
+        var sourceTable = JOOQUtils.resolveTable(application, application.getRelationSourceEntity(relation));
+        var targetTable = JOOQUtils.resolveTable(application, application.getRelationTargetEntity(relation));
         var sourcePrimaryKey = JOOQUtils.resolvePrimaryKey(application.getRelationSourceEntity(relation));
         var targetPrimaryKey = JOOQUtils.resolvePrimaryKey(application.getRelationTargetEntity(relation));
 
@@ -86,7 +86,7 @@ final class JOOQManyToManyRelationStrategy extends JOOQXToManyRelationStrategy<M
                 throw ExceptionUtils.handleException(e, () -> {
                     var targetEntityName = relation.getTargetEndPoint().getEntity();
                     var targetEntity = application.getRequiredEntityByName(targetEntityName);
-                    var targetTableName = JOOQUtils.resolveTable(targetEntity);
+                    var targetTableName = JOOQUtils.resolveTable(application, targetEntity);
                     var targetPrimaryKey = JOOQUtils.resolvePrimaryKey(targetEntity);
 
                     var targetUuids = targetIdentities.stream().map(t -> t.getEntityId().getValue()).collect(Collectors.toSet());

--- a/contentgrid-appserver-query-engine-impl-jooq/src/main/java/com/contentgrid/appserver/query/engine/jooq/strategy/JOOQManyToOneRelationStrategy.java
+++ b/contentgrid-appserver-query-engine-impl-jooq/src/main/java/com/contentgrid/appserver/query/engine/jooq/strategy/JOOQManyToOneRelationStrategy.java
@@ -13,7 +13,7 @@ final class JOOQManyToOneRelationStrategy extends JOOQXToOneRelationStrategy<Man
 
     @Override
     public Table<?> getTable(Application application, ManyToOneRelation relation) {
-        return JOOQUtils.resolveTable(application.getRelationSourceEntity(relation));
+        return JOOQUtils.resolveTable(application, application.getRelationSourceEntity(relation));
     }
 
     @Override

--- a/contentgrid-appserver-query-engine-impl-jooq/src/main/java/com/contentgrid/appserver/query/engine/jooq/strategy/JOOQOneToManyRelationStrategy.java
+++ b/contentgrid-appserver-query-engine-impl-jooq/src/main/java/com/contentgrid/appserver/query/engine/jooq/strategy/JOOQOneToManyRelationStrategy.java
@@ -29,7 +29,7 @@ final class JOOQOneToManyRelationStrategy extends JOOQXToManyRelationStrategy<On
 
     @Override
     public Table<?> getTable(Application application, OneToManyRelation relation) {
-        return JOOQUtils.resolveTable(application.getRelationTargetEntity(relation));
+        return JOOQUtils.resolveTable(application, application.getRelationTargetEntity(relation));
     }
 
     @Override
@@ -47,7 +47,7 @@ final class JOOQOneToManyRelationStrategy extends JOOQXToManyRelationStrategy<On
     public void make(DSLContext dslContext, Application application, OneToManyRelation relation) {
         var targetTable = getTable(application, relation);
         var sourceRef = getSourceRef(application, relation);
-        var sourceTable = JOOQUtils.resolveTable(application.getRelationSourceEntity(relation));
+        var sourceTable = JOOQUtils.resolveTable(application, application.getRelationSourceEntity(relation));
         var sourcePrimaryKey = JOOQUtils.resolvePrimaryKey(application.getRelationSourceEntity(relation));
 
         dslContext.alterTable(targetTable)

--- a/contentgrid-appserver-query-engine-impl-jooq/src/main/java/com/contentgrid/appserver/query/engine/jooq/strategy/JOOQSourceOneToOneRelationStrategy.java
+++ b/contentgrid-appserver-query-engine-impl-jooq/src/main/java/com/contentgrid/appserver/query/engine/jooq/strategy/JOOQSourceOneToOneRelationStrategy.java
@@ -14,7 +14,7 @@ final class JOOQSourceOneToOneRelationStrategy extends JOOQXToOneRelationStrateg
 
     @Override
     public Table<?> getTable(Application application, SourceOneToOneRelation relation) {
-        return JOOQUtils.resolveTable(application.getRelationSourceEntity(relation));
+        return JOOQUtils.resolveTable(application, application.getRelationSourceEntity(relation));
     }
 
     @Override

--- a/contentgrid-appserver-query-engine-impl-jooq/src/main/java/com/contentgrid/appserver/query/engine/jooq/strategy/JOOQTargetOneToOneRelationStrategy.java
+++ b/contentgrid-appserver-query-engine-impl-jooq/src/main/java/com/contentgrid/appserver/query/engine/jooq/strategy/JOOQTargetOneToOneRelationStrategy.java
@@ -29,7 +29,7 @@ final class JOOQTargetOneToOneRelationStrategy extends JOOQXToOneRelationStrateg
 
     @Override
     public Table<?> getTable(Application application, TargetOneToOneRelation relation) {
-        return JOOQUtils.resolveTable(application.getRelationTargetEntity(relation));
+        return JOOQUtils.resolveTable(application, application.getRelationTargetEntity(relation));
     }
 
     @Override

--- a/contentgrid-appserver-query-engine-impl-jooq/src/main/java/com/contentgrid/appserver/query/engine/jooq/strategy/JOOQXToOneRelationStrategy.java
+++ b/contentgrid-appserver-query-engine-impl-jooq/src/main/java/com/contentgrid/appserver/query/engine/jooq/strategy/JOOQXToOneRelationStrategy.java
@@ -40,7 +40,7 @@ public abstract sealed class JOOQXToOneRelationStrategy<R extends Relation> impl
         var table = getTable(application, relation);
         var foreignKey = getForeignKey(application, relation);
         var foreignEntity = getForeignEntity(application, relation);
-        var foreignTable = JOOQUtils.resolveTable(foreignEntity);
+        var foreignTable = JOOQUtils.resolveTable(application, foreignEntity);
         var foreignPrimaryKey = JOOQUtils.resolvePrimaryKey(foreignEntity);
 
         dslContext.alterTable(table)

--- a/contentgrid-appserver-query-engine-impl-jooq/src/main/java/com/contentgrid/appserver/query/engine/jooq/thunk/JOOQSymbolicReferenceResolver.java
+++ b/contentgrid-appserver-query-engine-impl-jooq/src/main/java/com/contentgrid/appserver/query/engine/jooq/thunk/JOOQSymbolicReferenceResolver.java
@@ -258,10 +258,10 @@ class JOOQSymbolicReferenceResolver {
         Condition where = null;
         for (var join : joins) {
             if (selectBuilder == null) {
-                selectBuilder = DSL.selectOne().from(JOOQUtils.resolveTable(join.getTargetTable(), join.getTargetAlias()));
+                selectBuilder = DSL.selectOne().from(JOOQUtils.resolveTable(application, join.getTargetTable(), join.getTargetAlias()));
                 where = join.getCondition();
             } else {
-                selectBuilder = selectBuilder.join(JOOQUtils.resolveTable(join.getTargetTable(), join.getTargetAlias()))
+                selectBuilder = selectBuilder.join(JOOQUtils.resolveTable(application, join.getTargetTable(), join.getTargetAlias()))
                         .on(join.getCondition());
             }
         }

--- a/contentgrid-appserver-query-engine-impl-jooq/src/test/java/com/contentgrid/appserver/query/engine/jooq/JOOQQueryEngineSchemaTest.java
+++ b/contentgrid-appserver-query-engine-impl-jooq/src/test/java/com/contentgrid/appserver/query/engine/jooq/JOOQQueryEngineSchemaTest.java
@@ -1,0 +1,212 @@
+package com.contentgrid.appserver.query.engine.jooq;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.contentgrid.appserver.application.model.Application;
+import com.contentgrid.appserver.application.model.Constraint;
+import com.contentgrid.appserver.application.model.Entity;
+import com.contentgrid.appserver.application.model.attributes.SimpleAttribute;
+import com.contentgrid.appserver.application.model.attributes.SimpleAttribute.Type;
+import com.contentgrid.appserver.application.model.relations.ManyToOneRelation;
+import com.contentgrid.appserver.application.model.relations.Relation.RelationEndPoint;
+import com.contentgrid.appserver.application.model.relations.flags.RequiredEndpointFlag;
+import com.contentgrid.appserver.application.model.settings.ApplicationSettings;
+import com.contentgrid.appserver.application.model.settings.database.DatabaseSettings;
+import com.contentgrid.appserver.application.model.values.ApplicationName;
+import com.contentgrid.appserver.application.model.values.AttributeName;
+import com.contentgrid.appserver.application.model.values.ColumnName;
+import com.contentgrid.appserver.application.model.values.EntityName;
+import com.contentgrid.appserver.application.model.values.LinkName;
+import com.contentgrid.appserver.application.model.values.PathSegmentName;
+import com.contentgrid.appserver.application.model.values.RelationName;
+import com.contentgrid.appserver.application.model.values.SchemaName;
+import com.contentgrid.appserver.application.model.values.TableName;
+import com.contentgrid.appserver.domain.values.EntityId;
+import com.contentgrid.appserver.domain.values.EntityRequest;
+import com.contentgrid.appserver.query.engine.api.CreateEventConsumer;
+import com.contentgrid.appserver.query.engine.api.QueryEngine;
+import com.contentgrid.appserver.query.engine.api.TableCreator;
+import com.contentgrid.appserver.query.engine.api.data.EntityCreateData;
+import com.contentgrid.appserver.query.engine.api.data.SimpleAttributeData;
+import com.contentgrid.appserver.query.engine.api.data.XToOneRelationData;
+import com.contentgrid.appserver.query.engine.api.exception.PermissionDeniedException;
+import com.contentgrid.appserver.query.engine.api.thunx.expression.StringComparison;
+import com.contentgrid.appserver.query.engine.jooq.test.JooqTest;
+import com.contentgrid.thunx.predicates.model.Scalar;
+import com.contentgrid.thunx.predicates.model.SymbolicReference;
+import com.contentgrid.thunx.predicates.model.ThunkExpression;
+import com.contentgrid.thunx.predicates.model.Variable;
+import java.math.BigDecimal;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+/**
+ * Regression test for ACC-3112: when the application uses a non-public database schema
+ * (configured via {@link DatabaseSettings}), the ABAC read predicate built by
+ * {@code JOOQSymbolicReferenceResolver} for {@link JOOQQueryEngine#findById} renders a
+ * correlated {@code EXISTS} subquery that references the outer table alias with a schema
+ * qualifier (e.g. {@code "cgtest"."i0"."customer"}), which PostgreSQL rejects with
+ * {@code "invalid reference to FROM-clause entry for table \"i0\""}.
+ * <p>
+ * As a result, fetching a single entity the user is not authorized to read returns
+ * {@code 500 Internal Server Error} (a {@code DataAccessException}) instead of the expected
+ * {@code 403 Forbidden} ({@link PermissionDeniedException}).
+ * <p>
+ * The existing {@link JOOQQueryEngineTest} runs against the default {@code public} schema, so
+ * the schema prefix is never rendered and the bug cannot surface there.
+ */
+@JooqTest
+class JOOQQueryEngineSchemaTest {
+
+    private static final Variable ENTITY_VAR = Variable.named("entity");
+    private static final ThunkExpression<Boolean> PERMIT_CUSTOMER_ALICE = StringComparison.normalizedEqual(
+            SymbolicReference.of(ENTITY_VAR, SymbolicReference.path("customer"), SymbolicReference.path("name")),
+            Scalar.of("alice")
+    );
+
+    private static final SimpleAttribute PERSON_NAME = SimpleAttribute.builder()
+            .name(AttributeName.of("name"))
+            .column(ColumnName.of("name"))
+            .type(Type.TEXT)
+            .constraint(Constraint.required())
+            .build();
+
+    private static final SimpleAttribute INVOICE_NUMBER = SimpleAttribute.builder()
+            .name(AttributeName.of("number"))
+            .column(ColumnName.of("number"))
+            .type(Type.TEXT)
+            .constraint(Constraint.required())
+            .build();
+
+    private static final SimpleAttribute INVOICE_AMOUNT = SimpleAttribute.builder()
+            .name(AttributeName.of("amount"))
+            .column(ColumnName.of("amount"))
+            .type(Type.DOUBLE)
+            .constraint(Constraint.required())
+            .build();
+
+    private static final Entity PERSON = Entity.builder()
+            .name(EntityName.of("person"))
+            .table(TableName.of("person"))
+            .pathSegment(PathSegmentName.of("persons"))
+            .linkName(LinkName.of("persons"))
+            .attribute(PERSON_NAME)
+            .build();
+
+    private static final Entity INVOICE = Entity.builder()
+            .name(EntityName.of("invoice"))
+            .table(TableName.of("invoice"))
+            .pathSegment(PathSegmentName.of("invoices"))
+            .linkName(LinkName.of("invoices"))
+            .attribute(INVOICE_NUMBER)
+            .attribute(INVOICE_AMOUNT)
+            .build();
+
+    private static final ManyToOneRelation INVOICE_CUSTOMER = ManyToOneRelation.builder()
+            .sourceEndPoint(RelationEndPoint.builder()
+                    .entity(INVOICE.getName())
+                    .name(RelationName.of("customer"))
+                    .pathSegment(PathSegmentName.of("customer"))
+                    .linkName(LinkName.of("customer"))
+                    .flag(RequiredEndpointFlag.INSTANCE)
+                    .build())
+            .targetEndPoint(RelationEndPoint.builder()
+                    .entity(PERSON.getName())
+                    .name(RelationName.of("invoices"))
+                    .pathSegment(PathSegmentName.of("invoices"))
+                    .linkName(LinkName.of("invoices"))
+                    .build())
+            .targetReference(ColumnName.of("customer"))
+            .build();
+
+    /**
+     * Application backed by a non-public schema. This is what triggers
+     * {@link com.contentgrid.appserver.query.engine.jooq.resolver.AutowiredDSLContextResolver}
+     * to add a schema {@code RenderMapping} to the jOOQ {@code DSLContext}.
+     */
+    private static final Application APPLICATION = Application.builder()
+            .name(ApplicationName.of("schema-test-application"))
+            .entity(INVOICE)
+            .entity(PERSON)
+            .relation(INVOICE_CUSTOMER)
+            .settings(ApplicationSettings.builder()
+                    .database(DatabaseSettings.builder()
+                            .schema(SchemaName.of("cgtest"))
+                            .build())
+                    .build())
+            .build();
+
+    @Autowired
+    private TableCreator tableCreator;
+
+    @Autowired
+    private QueryEngine queryEngine;
+
+    @MockitoBean
+    private CreateEventConsumer createEventConsumer;
+
+    private EntityId aliceId;
+    private EntityId bobId;
+    private EntityId invoiceForAliceId;
+    private EntityId invoiceForBobId;
+
+    @BeforeEach
+    void setup() {
+        tableCreator.createTables(APPLICATION);
+
+        var alice = queryEngine.create(APPLICATION, EntityCreateData.builder()
+                .entityName(PERSON.getName())
+                .attribute(SimpleAttributeData.builder().name(PERSON_NAME.getName()).value("alice").build())
+                .build(), Scalar.of(true), createEventConsumer);
+        aliceId = alice.getIdentity().getEntityId();
+
+        var bob = queryEngine.create(APPLICATION, EntityCreateData.builder()
+                .entityName(PERSON.getName())
+                .attribute(SimpleAttributeData.builder().name(PERSON_NAME.getName()).value("bob").build())
+                .build(), Scalar.of(true), createEventConsumer);
+        bobId = bob.getIdentity().getEntityId();
+
+        var invoiceForAlice = queryEngine.create(APPLICATION, EntityCreateData.builder()
+                .entityName(INVOICE.getName())
+                .attribute(SimpleAttributeData.builder().name(INVOICE_NUMBER.getName()).value("invoice_a").build())
+                .attribute(SimpleAttributeData.builder().name(INVOICE_AMOUNT.getName()).value(BigDecimal.valueOf(10.0)).build())
+                .relation(XToOneRelationData.builder().name(INVOICE_CUSTOMER.getSourceEndPoint().getName()).ref(aliceId).build())
+                .build(), Scalar.of(true), createEventConsumer);
+        invoiceForAliceId = invoiceForAlice.getIdentity().getEntityId();
+
+        var invoiceForBob = queryEngine.create(APPLICATION, EntityCreateData.builder()
+                .entityName(INVOICE.getName())
+                .attribute(SimpleAttributeData.builder().name(INVOICE_NUMBER.getName()).value("invoice_b").build())
+                .attribute(SimpleAttributeData.builder().name(INVOICE_AMOUNT.getName()).value(BigDecimal.valueOf(20.0)).build())
+                .relation(XToOneRelationData.builder().name(INVOICE_CUSTOMER.getSourceEndPoint().getName()).ref(bobId).build())
+                .build(), Scalar.of(true), createEventConsumer);
+        invoiceForBobId = invoiceForBob.getIdentity().getEntityId();
+    }
+
+    @AfterEach
+    void cleanup() {
+        tableCreator.dropTables(APPLICATION);
+    }
+
+    @Test
+    void findByIdWithRelationBasedPermissionAgainstNonPublicSchema() {
+        // invoice whose customer is alice -> permitted, must be returned
+        var permitted = queryEngine.findById(APPLICATION,
+                EntityRequest.forEntity(INVOICE.getName(), invoiceForAliceId), PERMIT_CUSTOMER_ALICE);
+        assertThat(permitted).isPresent();
+        assertThat(permitted.get().getAttributeByName(INVOICE_NUMBER.getName()))
+                .hasValueSatisfying(attr -> assertThat(((SimpleAttributeData<?>) attr).getValue()).isEqualTo("invoice_a"));
+
+        // invoice whose customer is bob -> NOT permitted.
+        // BUG (ACC-3112): this throws a jOOQ DataAccessException (SQL error
+        // "invalid reference to FROM-clause entry for table i0") instead of PermissionDeniedException,
+        // because the correlated EXISTS subquery renders the outer alias as "cgtest"."i0"."customer".
+        var thrown = assertThrows(PermissionDeniedException.class, () -> queryEngine.findById(APPLICATION,
+                EntityRequest.forEntity(INVOICE.getName(), invoiceForBobId), PERMIT_CUSTOMER_ALICE));
+        assertThat(thrown.getEntityId()).isEqualTo(invoiceForBobId);
+    }
+}


### PR DESCRIPTION
## Problem

When an application is configured with a non-public database schema (`ApplicationSettings.database.schema`), `GET /{entity}/{id}` against an item covered by an ABAC read predicate that references a relation returns **HTTP 500** instead of **HTTP 403** (or 200 for permitted items).

This breaks the management-platform `HelmIntegrationTest` (PR [xenit-eu/contentgrid-management-platform#1733](https://github.com/xenit-eu/contentgrid-management-platform/pull/1733)):

```
expected: <403> but was: <500>
```

## Root cause

`AutowiredDSLContextResolver` (ACC-3028, #317) applies the application's `DatabaseSettings.schema` globally via a jOOQ [`RenderMapping`](https://www.jooq.org/doc/latest/manual/sql-building/dsl-context/custom-settings/settings-render-mapping/) (`MappedSchema(input="" → output=schema)`).

The ABAC `findById` path builds a correlated `EXISTS` subquery (`_allow_read`) in `JOOQSymbolicReferenceResolver`. The outer table alias is referenced inside that subquery via `JOOQUtils.resolveField(alias, column)`, which builds an **unbound** field: `DSL.field(DSL.name(alias, column))`. The `RenderMapping` rewrites *all* unbound names, so it qualifies this correlated alias reference as a 3-part name:

```sql
-- rendered (broken)
select ... from "V1"."invoice" as "i0"
where exists (
  select 1 from "V1"."person" as "p0"
  where "V1"."i0"."customer" = "p0"."id"   -- ← schema-qualified alias
)
```

PostgreSQL rejects the 3-part reference to the outer alias:

```
org.postgresql.util.PSQLException: ERROR: invalid reference to FROM-clause entry for table "i0"
Hint: There is an entry for table "i0", but it cannot be referenced from this part of the query.
```

jOOQ wraps this in a `DataAccessException`, which surfaces as HTTP 500.

The `RenderMapping` is the wrong tool here: it cannot distinguish a table name (which *should* be schema-qualified) from a correlated alias reference (which must *not* be).

## Fix

Apply the schema **only to table references**, not globally:

- **`JOOQUtils`** — add `resolveTable(Application, ...)` overloads that schema-qualify the table name with `DatabaseSettings.schema` when it is non-`PUBLIC`. Field/column references (`resolveField`, `resolvePrimaryKey`, …) stay unqualified, which is correct for correlated aliases.
- **`AutowiredDSLContextResolver`** — drop the `RenderMapping`; `resolve()` returns the autowired `DSLContext` unchanged.
- **`JOOQQueryEngine`, `JOOQTableCreator`, `JOOQSymbolicReferenceResolver`, relation strategies** — pass `Application` to all `resolveTable` call sites.

Rendered SQL after the fix:

```sql
select ... from "V1"."invoice" as "i0"
where exists (
  select 1 from "V1"."person" as "p0"
  where "i0"."customer" = "p0"."id"        -- ← 2-part alias, valid
)
```

`JOOQTableCreator` already created tables in the application schema, so read/write paths keep targeting the correct schema.

## Why existing tests missed it

- `JooqTest` (Testcontainers Postgres) uses the default `public` schema → no schema prefix rendered → no `RenderMapping` effect.
- `JOOQSymbolicReferenceResolverTest` compares AST equality, not rendered SQL, so the 3-part name was never observed.

## Test

`JOOQQueryEngineSchemaTest` (added in this PR) reproduces the failure: it runs `JOOQQueryEngine.findById()` with a relation-based ABAC read predicate against an application with `DatabaseSettings.schema=cgtest`. On `main` it fails with the `PSQLException`; with the fix it returns the permitted item / throws `PermissionDeniedException` as expected.

## Scope note

This regresses schema placement of the content-encryption `_dek_storage` table only for apps that combine *content encryption* with a *non-public schema*: that table is created via a hardcoded `dslContext.createTableIfNotExists("_dek_storage")` in `TableStorageDataEncryptionKeyAccessor`, which previously got schema-qualified by the `RenderMapping`. No encryption test uses a non-public schema today, and the management-platform scenario (no content encryption) is unaffected. Filed as follow-up.